### PR TITLE
Add Travis-CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: c
+compiler: gcc
+before_script: git clone https://github.com/snowballstem/snowball-data ../data
+script:  make check


### PR DESCRIPTION
This pulls in the test data from its github repository, and checks that
"make check" is succcessful.  Currently, this doesn't check the Java
support, but is a good start.

This is based on the changes from @oerd in #5, but since that PR
was opened further unrelated changes were made to the branch, so
I can't simply merge it.
