### PR TITLE
/usr/env perl instead of /usr/bin/perl

### DIFF
--- a/libstemmer/mkmodules.pl
+++ b/libstemmer/mkmodules.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 use strict;
 use Getopt::Std;
 


### PR DESCRIPTION
This fixes an issue where it doesn't work if `perl` is in a nonstandard location.
