### PR TITLE
Fix Java generation

### DIFF
--- a/compiler/generator_java.c
+++ b/compiler/generator_java.c
@@ -998,7 +998,7 @@ static void generate_literalstring(struct generator * g, struct node * p) {
     write_comment(g, p);
     g->S[0] = p->mode == m_forward ? "" : "_b";
     g->L[0] = b;
-    write_failure_if(g, "!(eq_s~S0(~I0))", p);
+    write_failure_if(g, "!(eq_s~S0(~L0))", p);
 }
 
 static void generate_define(struct generator * g, struct node * p) {

--- a/java/org/tartarus/snowball/SnowballProgram.java
+++ b/java/org/tartarus/snowball/SnowballProgram.java
@@ -113,23 +113,23 @@ public class SnowballProgram {
 
     protected boolean eq_s(CharSequence s)
     {
-	if (limit - cursor < s.length) return false;
+	if (limit - cursor < s.length()) return false;
 	int i;
-	for (i = 0; i != s.length; i++) {
+	for (i = 0; i != s.length(); i++) {
 	    if (current.charAt(cursor + i) != s.charAt(i)) return false;
 	}
-	cursor += s.length;
+	cursor += s.length();
 	return true;
     }
 
     protected boolean eq_s_b(CharSequence s)
     {
-	if (cursor - limit_backward < s.length) return false;
+	if (cursor - limit_backward < s.length()) return false;
 	int i;
-	for (i = 0; i != s.length; i++) {
-	    if (current.charAt(cursor - s.length + i) != s.charAt(i)) return false;
+	for (i = 0; i != s.length(); i++) {
+	    if (current.charAt(cursor - s.length() + i) != s.charAt(i)) return false;
 	}
-	cursor -= s.length;
+	cursor -= s.length();
 	return true;
     }
 


### PR DESCRIPTION
In generator_java.c: `eq_s` and `eq_s_b` take the literal string, not the string’s length.

In SnowballProgram.java: `CharSequence#length` is a method.