### PR TITLE
Make Java classes implement Serializable

### DIFF
--- a/java/org/tartarus/snowball/SnowballProgram.java
+++ b/java/org/tartarus/snowball/SnowballProgram.java
@@ -1,13 +1,16 @@
 
 package org.tartarus.snowball;
 import java.lang.reflect.InvocationTargetException;
+import java.io.Serializable;
 
-public class SnowballProgram {
+public class SnowballProgram implements Serializable {
     protected SnowballProgram()
     {
 	current = new StringBuffer();
 	setCurrent("");
     }
+
+    static final long serialVersionUID = 2016072500L;
 
     /**
      * Set the current string.

--- a/java/org/tartarus/snowball/SnowballStemmer.java
+++ b/java/org/tartarus/snowball/SnowballStemmer.java
@@ -4,4 +4,6 @@ import java.lang.reflect.InvocationTargetException;
 
 public abstract class SnowballStemmer extends SnowballProgram {
     public abstract boolean stem();
+
+    static final long serialVersionUID = 2016072500L;
 };


### PR DESCRIPTION
Classes need to be serializable in order to use them in [Apache Spark](https://spark.apache.org/) and similar frameworks.