### PR TITLE
Strip diaeresis from "gü" and "guë" in French

### DIFF
--- a/algorithms/french/stem_ISO_8859_1.sbl
+++ b/algorithms/french/stem_ISO_8859_1.sbl
@@ -30,6 +30,7 @@ stringdef e`   hex 'E8'  // e-grave
 stringdef i"   hex 'EF'  // i-diaeresis
 stringdef i^   hex 'EE'  // i-circumflex
 stringdef o^   hex 'F4'  // o-circumflex
+stringdef u"   hex 'FC'  // u-diaeresis
 stringdef u^   hex 'FB'  // u-circumflex
 stringdef u`   hex 'F9'  // u-grave
 
@@ -45,6 +46,8 @@ define prelude as repeat goto (
     (  ['y'] v <- 'Y' )
     or
     (  'q' ['u'] <- 'U' )
+    or
+    ( 'g' ['{u"}'] v <- 'u' )
 )
 
 define mark_regions as (
@@ -197,13 +200,13 @@ backwardmode (
 
     define residual_suffix as (
         try(['s'] test non-keep_with_s delete)
+        try(['{e"}'] test 'gu' delete)
         setlimit tomark pV for (
             [substring] among(
                 'ion'           (R2 's' or 't' delete)
                 'ier' 'i{e`}re'
                 'Ier' 'I{e`}re' (<-'i')
                 'e'             (delete)
-                '{e"}'          ('gu' delete)
             )
         )
     )

--- a/algorithms/french/stem_MS_DOS_Latin_I.sbl
+++ b/algorithms/french/stem_MS_DOS_Latin_I.sbl
@@ -30,6 +30,7 @@ stringdef e`   hex '8A'  // e-grave
 stringdef i"   hex '8B'  // i-diaeresis
 stringdef i^   hex '8C'  // i-circumflex
 stringdef o^   hex '93'  // o-circumflex
+stringdef u"   hex '81'  // u-diaeresis
 stringdef u^   hex '96'  // u-circumflex
 stringdef u`   hex '97'  // u-grave
 
@@ -45,6 +46,8 @@ define prelude as repeat goto (
     (  ['y'] v <- 'Y' )
     or
     (  'q' ['u'] <- 'U' )
+    or
+    ( 'g' ['{u"}'] v <- 'u' )
 )
 
 define mark_regions as (
@@ -197,13 +200,13 @@ backwardmode (
 
     define residual_suffix as (
         try(['s'] test non-keep_with_s delete)
+        try(['{e"}'] test 'gu' delete)
         setlimit tomark pV for (
             [substring] among(
                 'ion'           (R2 's' or 't' delete)
                 'ier' 'i{e`}re'
                 'Ier' 'I{e`}re' (<-'i')
                 'e'             (delete)
-                '{e"}'          ('gu' delete)
             )
         )
     )


### PR DESCRIPTION
`residual_suffix` was broken: deleting "ë" after "gu" did not work, so "aiguë" was stemmed to "aiguë" instead of the intended "aigu". While I was at it, I normalized "gü" to "gu" before a vowel, as in "aigüe" and "ambigüité".
