### PR TITLE
[Italian] "divano" overstemmed

### DIFF
--- a/algorithms/italian/stem_ISO_8859_1.sbl
+++ b/algorithms/italian/stem_ISO_8859_1.sbl
@@ -147,7 +147,7 @@ backwardmode (
 
     define verb_suffix as setlimit tomark pV for (
         [substring] among(
-            'ammo' 'ando' 'ano' 'are' 'arono' 'asse' 'assero' 'assi'
+            'ammo' 'ando' 'ano' 'ani' 'are' 'arono' 'asse' 'assero' 'assi'
             'assimo' 'ata' 'ate' 'ati' 'ato' 'ava' 'avamo' 'avano' 'avate'
             'avi' 'avo' 'emmo' 'enda' 'ende' 'endi' 'endo' 'er{a`}' 'erai'
             'eranno' 'ere' 'erebbe' 'erebbero' 'erei' 'eremmo' 'eremo'


### PR DESCRIPTION
this pull request fix the issue with word divani and similar *ani suffix words.

An example is "divano" is stemmed correctly to "div", but it's pluaral "divani" is stemmed in "divan"