### PR TITLE
Avoid generating `--` from two `-` operators

### DIFF
--- a/compiler/generator.c
+++ b/compiler/generator.c
@@ -313,7 +313,7 @@ static void generate_AE(struct generator * g, struct node * p) {
         case c_minint:
             write_string(g, "MININT"); break;
         case c_neg:
-            write_char(g, '-'); generate_AE(g, p->right); break;
+            write_string(g, "- "); generate_AE(g, p->right); break;
         case c_multiply:
             s = " * "; goto label0;
         case c_plus:

--- a/compiler/generator_java.c
+++ b/compiler/generator_java.c
@@ -279,7 +279,7 @@ static void generate_AE(struct generator * g, struct node * p) {
         case c_minint:
             write_string(g, "Integer.MIN_VALUE"); break;
         case c_neg:
-            write_char(g, '-'); generate_AE(g, p->right); break;
+            write_string(g, "- "); generate_AE(g, p->right); break;
         case c_multiply:
             s = " * "; goto label0;
         case c_plus:

--- a/compiler/generator_jsx.c
+++ b/compiler/generator_jsx.c
@@ -278,7 +278,7 @@ static void generate_AE(struct generator * g, struct node * p) {
         case c_minint:
             write_string(g, "(~(-1>>>1))"); break;
         case c_neg:
-            write_char(g, '-'); generate_AE(g, p->right); break;
+            write_string(g, "- "); generate_AE(g, p->right); break;
         case c_multiply:
             s = " * "; goto label0;
         case c_plus:


### PR DESCRIPTION
The C, Java, and JSX files generated from this source:
```snowball
externals (stem)
define stem as ([hop --1] delete)
```
contain the invalid syntax `--1`. This commit adds a space after the unary `-` operator in those three languages. Python and Rust don’t have the `--` operator, so their generators don’t need changing. C# does, so its generator will.