### PR TITLE
fix potential memory leak (found by clang static analyzer)

### DIFF
--- a/libstemmer/libstemmer_c.in
+++ b/libstemmer/libstemmer_c.in
@@ -67,9 +67,10 @@ void
 sb_stemmer_delete(struct sb_stemmer * stemmer)
 {
     if (stemmer == 0) return;
-    if (stemmer->close == 0) return;
-    stemmer->close(stemmer->env);
-    stemmer->close = 0;
+    if (stemmer->close) {
+        stemmer->close(stemmer->env);
+        stemmer->close = 0;
+    }
     free(stemmer);
 }
 


### PR DESCRIPTION
Minor fix to silence Xcode warning: if `stemmer->close` is `NULL`, then `sb_stemmer_delete` leaks memory.