### PR TITLE
Fix Rust expressions with `as` and remove unused imports

### DIFF
--- a/compiler/generator_rust.c
+++ b/compiler/generator_rust.c
@@ -1120,7 +1120,9 @@ static void generate_allow_warnings(struct generator * g) {
 static void generate_class_begin(struct generator * g) {
 
     w(g, "use snowball::SnowballEnv;~N");
-    w(g, "use snowball::Among;~N~N");
+    if (g->analyser->among_count > 0) {
+        w(g, "use snowball::Among;~N~N");
+    }
 }
 
 static void generate_among_table(struct generator * g, struct among * x) {


### PR DESCRIPTION
The Snowball arithmetic expression `-len` is converted into the Rust expression `-env.current.chars().count() as i32`, which fails with <code>error[E0600]: cannot apply unary operator &#x60;-&#x60; to type &#x60;usize&#x60;</code> because the binary operator `as` binds less tightly than the unary operator `-`. The solution is to parenthesize all `as` expressions.

While I was at it I made the generator import `snowball::Among` conditionally so that stemmers that don’t use `among` don’t produce <code>warning: unused import: &#x60;snowball::Among&#x60;</code>.