### PR TITLE
fix wrong cache clearing in python stemmer class

### DIFF
--- a/python/snowballstemmer/basestemmer.py
+++ b/python/snowballstemmer/basestemmer.py
@@ -303,5 +303,5 @@ class BaseStemmer(object):
     def stemWords(self, words):
         result = [self._stem_word(word) for word in words]
         if len(self._cache) > self.maxCacheSize:
-            self.clear_cache()
+            self._clear_cache()
         return result


### PR DESCRIPTION
stemWords method in python BaseStemmer class call a invalid method `clear_cache` instead of `_clear_cach`, this PR fix this issue.