### PR TITLE
Optimise code generated for `do <function call>`

### DIFF
--- a/compiler/generator_csharp.c
+++ b/compiler/generator_csharp.c
@@ -484,14 +484,21 @@ static void generate_do(struct generator * g, struct node * p) {
         write_savecursor(g, p, savevar);
     }
 
-    g->failure_label = new_label(g);
-    g->label_used = 0;
-    str_clear(g->failure_str);
+    if (p->left->type == c_call) {
+        /* Optimise do <call> */
+        write_comment(g, p->left);
+        g->V[0] = p->left->name;
+        w(g, "~M~V0();~N");
+    } else {
+        g->failure_label = new_label(g);
+        g->label_used = 0;
+        str_clear(g->failure_str);
 
-    generate(g, p->left);
+        generate(g, p->left);
 
-    if (g->label_used)
-        wsetl(g, g->failure_label);
+        if (g->label_used)
+            wsetl(g, g->failure_label);
+    }
 
     if (keep_c) {
         write_restorecursor(g, p, savevar);

--- a/compiler/generator_go.c
+++ b/compiler/generator_go.c
@@ -480,14 +480,22 @@ static void generate_do(struct generator * g, struct node * p) {
     int keep_c = K_needed(g, p->left);
     write_comment(g, p);
     if (keep_c) write_savecursor(g, p, savevar);
-    g->failure_label = new_label(g);
-    int label = g->failure_label;
-    str_clear(g->failure_str);
 
-    wsetlab_begin(g, label);
-    generate(g, p->left);
-    wsetlab_end(g, label);
-    g->unreachable = false;
+    if (p->left->type == c_call) {
+        /* Optimise do <call> */
+        write_comment(g, p->left);
+        g->V[0] = p->left->name;
+        w(g, "~M~V0()~N");
+    } else {
+        g->failure_label = new_label(g);
+        int label = g->failure_label;
+        str_clear(g->failure_str);
+
+        wsetlab_begin(g, label);
+        generate(g, p->left);
+        wsetlab_end(g, label);
+        g->unreachable = false;
+    }
 
     if (keep_c) write_restorecursor(g, p, savevar);
     str_delete(savevar);

--- a/compiler/generator_go.c
+++ b/compiler/generator_go.c
@@ -485,7 +485,7 @@ static void generate_do(struct generator * g, struct node * p) {
         /* Optimise do <call> */
         write_comment(g, p->left);
         g->V[0] = p->left->name;
-        w(g, "~M~V0()~N");
+        w(g, "~M~W0(env, context)~N");
     } else {
         g->failure_label = new_label(g);
         int label = g->failure_label;

--- a/compiler/generator_java.c
+++ b/compiler/generator_java.c
@@ -472,13 +472,20 @@ static void generate_do(struct generator * g, struct node * p) {
     write_comment(g, p);
     if (keep_c) write_savecursor(g, p, savevar);
 
-    g->failure_label = new_label(g);
-    str_clear(g->failure_str);
+    if (p->left->type == c_call) {
+        /* Optimise do <call> */
+        write_comment(g, p->left);
+        g->V[0] = p->left->name;
+        w(g, "~M~V0();~N");
+    } else {
+        g->failure_label = new_label(g);
+        str_clear(g->failure_str);
 
-    wsetlab_begin(g, g->failure_label);
-    generate(g, p->left);
-    wsetlab_end(g);
-    g->unreachable = false;
+        wsetlab_begin(g, g->failure_label);
+        generate(g, p->left);
+        wsetlab_end(g);
+        g->unreachable = false;
+    }
 
     if (keep_c) write_restorecursor(g, p, savevar);
     str_delete(savevar);

--- a/compiler/generator_js.c
+++ b/compiler/generator_js.c
@@ -468,13 +468,20 @@ static void generate_do(struct generator * g, struct node * p) {
     write_comment(g, p);
     if (keep_c) write_savecursor(g, p, savevar);
 
-    g->failure_label = new_label(g);
-    str_clear(g->failure_str);
+    if (p->left->type == c_call) {
+        /* Optimise do <call> */
+        write_comment(g, p->left);
+        g->V[0] = p->left->name;
+        w(g, "~M~V0();~N");
+    } else {
+        g->failure_label = new_label(g);
+        str_clear(g->failure_str);
 
-    wsetlab_begin(g, g->failure_label);
-    generate(g, p->left);
-    wsetlab_end(g);
-    g->unreachable = false;
+        wsetlab_begin(g, g->failure_label);
+        generate(g, p->left);
+        wsetlab_end(g);
+        g->unreachable = false;
+    }
 
     if (keep_c) write_restorecursor(g, p, savevar);
     str_delete(savevar);

--- a/compiler/generator_pascal.c
+++ b/compiler/generator_pascal.c
@@ -486,13 +486,20 @@ static void generate_do(struct generator * g, struct node * p) {
     write_comment(g, p);
     if (keep_c) write_savecursor(g, p, savevar);
 
-    g->failure_label = new_label(g);
-    str_clear(g->failure_str);
+    if (p->left->type == c_call) {
+        /* Optimise do <call> */
+        write_comment(g, p->left);
+        g->V[0] = p->left->name;
+        w(g, "~M~V0();~N");
+    } else {
+        g->failure_label = new_label(g);
+        str_clear(g->failure_str);
 
-    wsetlab_begin(g);
-    generate(g, p->left);
-    wsetlab_end(g, g->failure_label);
-    g->unreachable = false;
+        wsetlab_begin(g);
+        generate(g, p->left);
+        wsetlab_end(g, g->failure_label);
+        g->unreachable = false;
+    }
 
     if (keep_c) write_restorecursor(g, p, savevar);
     str_delete(savevar);

--- a/compiler/generator_python.c
+++ b/compiler/generator_python.c
@@ -474,14 +474,21 @@ static void generate_do(struct generator * g, struct node * p) {
     write_comment(g, p);
     if (keep_c) write_savecursor(g, p, savevar);
 
-    g->failure_label = new_label(g);
-    int label = g->failure_label;
-    str_clear(g->failure_str);
+    if (p->left->type == c_call) {
+        /* Optimise do <call> */
+        write_comment(g, p->left);
+        g->V[0] = p->left->name;
+        w(g, "~M~V0()~N");
+    } else {
+        g->failure_label = new_label(g);
+        int label = g->failure_label;
+        str_clear(g->failure_str);
 
-    wsetlab_begin(g);
-    generate(g, p->left);
-    wsetlab_end(g, label);
-    g->unreachable = false;
+        wsetlab_begin(g);
+        generate(g, p->left);
+        wsetlab_end(g, label);
+        g->unreachable = false;
+    }
 
     if (keep_c) write_restorecursor(g, p, savevar);
     str_delete(savevar);

--- a/compiler/generator_rust.c
+++ b/compiler/generator_rust.c
@@ -479,14 +479,22 @@ static void generate_do(struct generator * g, struct node * p) {
     int keep_c = K_needed(g, p->left);
     write_comment(g, p);
     if (keep_c) write_savecursor(g, p, savevar);
-    g->failure_label = new_label(g);
-    int label = g->failure_label;
-    str_clear(g->failure_str);
 
-    wsetlab_begin(g, label);
-    generate(g, p->left);
-    wsetlab_end(g, label);
-    g->unreachable = false;
+    if (p->left->type == c_call) {
+        /* Optimise do <call> */
+        write_comment(g, p->left);
+        g->V[0] = p->left->name;
+        w(g, "~M~W0(env, context);~N");
+    } else {
+        g->failure_label = new_label(g);
+        int label = g->failure_label;
+        str_clear(g->failure_str);
+
+        wsetlab_begin(g, label);
+        generate(g, p->left);
+        wsetlab_end(g, label);
+        g->unreachable = false;
+    }
 
     if (keep_c) write_restorecursor(g, p, savevar);
     str_delete(savevar);


### PR DESCRIPTION
This speeds up "make check_python" by about 2%, and should speed up
other interpreted languages too.