### PR TITLE
Fix Bare Trait Warnings

### DIFF
--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -56,9 +56,9 @@ fn main() {
 
 
         let mut output = if let Some(output_file) = output_arg {
-            Box::new(File::create(Path::new(&output_file)).unwrap()) as Box<Write>
+            Box::new(File::create(Path::new(&output_file)).unwrap()) as Box<dyn Write>
         } else {
-            Box::new(std::io::stdout()) as Box<Write>
+            Box::new(std::io::stdout()) as Box<dyn Write>
         };
 
         if let Some(input_file) = input_arg {

--- a/rust/src/snowball/among.rs
+++ b/rust/src/snowball/among.rs
@@ -3,4 +3,4 @@ use snowball::SnowballEnv;
 pub struct Among<T: 'static>(pub &'static str,
                              pub i32,
                              pub i32,
-                             pub Option<&'static (Fn(&mut SnowballEnv, &mut T) -> bool + Sync)>);
+                             pub Option<&'static (dyn Fn(&mut SnowballEnv, &mut T) -> bool + Sync)>);


### PR DESCRIPTION
In Rust 1.27 the `dyn` keyword was introduced to counter the confusions introduced with the `impl Trait` syntax. ([RFC-2113](https://github.com/Ixrec/rfcs/blob/dyn-trait-syntax/text/2113-dyn-trait-syntax.md))

This PR adds the `dyn` keyword at all necessary places. The cost being that it will not be possible to compile it with Rust 1.26 and below.

The alternative would be to suppress this warning.