### PR TITLE
snowball/stemwords: do link with LDFLAGS set by build-system

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -178,7 +178,7 @@ clean:
 	-rmdir $(js_output_dir)
 
 snowball: $(COMPILER_OBJECTS)
-	$(CC) $(CFLAGS) -o $@ $^
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^
 
 $(COMPILER_OBJECTS): $(COMPILER_HEADERS)
 
@@ -200,7 +200,7 @@ libstemmer.o: libstemmer/libstemmer.o $(RUNTIME_OBJECTS) $(C_LIB_OBJECTS)
 	$(AR) -cru $@ $^
 
 stemwords: $(STEMWORDS_OBJECTS) libstemmer.o
-	$(CC) $(CFLAGS) -o $@ $^
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^
 
 csharp_stemwords: $(CSHARP_STEMWORDS_SOURCES) $(CSHARP_RUNTIME_SOURCES) $(CSHARP_SOURCES)
 	$(MCS) -unsafe -target:exe -out:$@ $(CSHARP_STEMWORDS_SOURCES) $(CSHARP_RUNTIME_SOURCES) $(CSHARP_SOURCES)


### PR DESCRIPTION
Some (cross-)build systems as OpeneEmbedded are picky (for certain reasons) if
their LDFLAGS are ignored.

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>