### PR TITLE
Grouping improvements

### DIFF
--- a/compiler/analyser.c
+++ b/compiler/analyser.c
@@ -1063,7 +1063,6 @@ static void read_define_grouping(struct analyser * a, struct name * q) {
         if (q) q->grouping = p;
         p->next = 0;
         p->name = q;
-        p->number = q ? q->count : 0;
         p->line_number = a->tokeniser->line_number;
         p->b = create_b(0);
         while (true) {

--- a/compiler/analyser.c
+++ b/compiler/analyser.c
@@ -293,6 +293,7 @@ handle_as_name:
                     p->used = 0;
                     p->value_used = false;
                     p->initialised = false;
+                    p->used_in_definition = false;
                     p->local_to = 0;
                     p->grouping = 0;
                     p->definition = 0;
@@ -1073,6 +1074,7 @@ static void read_define_grouping(struct analyser * a, struct name * q) {
                         if (r) {
                             check_name_type(a, r, 'g');
                             p->b = alter_grouping(p->b, r->grouping->b, style, false);
+                            r->used_in_definition = true;
                         }
                     }
                     break;
@@ -1221,7 +1223,10 @@ extern void read_program(struct analyser * a) {
                     fprintf(stderr, "' defined but not used\n");
                 }
             } else if (q->type == t_routine || q->type == t_grouping) {
-                if (!q->used) {
+                /* It's OK to define a grouping but only use it to define other
+                 * groupings.
+                 */
+                if (!q->used && !q->used_in_definition) {
                     int line_num;
                     if (q->type == t_routine) {
                         line_num = q->definition->line_number;

--- a/compiler/generator.c
+++ b/compiler/generator.c
@@ -1539,7 +1539,8 @@ static void generate_grouping_table(struct generator * g, struct grouping * q) {
 static void generate_groupings(struct generator * g) {
     struct grouping * q;
     for (q = g->analyser->groupings; q; q = q->next) {
-        generate_grouping_table(g, q);
+        if (q->name->used)
+            generate_grouping_table(g, q);
     }
 }
 

--- a/compiler/generator_csharp.c
+++ b/compiler/generator_csharp.c
@@ -1250,7 +1250,8 @@ static void generate_grouping_table(struct generator * g, struct grouping * q) {
 static void generate_groupings(struct generator * g) {
     struct grouping * q;
     for (q = g->analyser->groupings; q; q = q->next) {
-        generate_grouping_table(g, q);
+        if (q->name->used)
+            generate_grouping_table(g, q);
     }
 }
 

--- a/compiler/generator_go.c
+++ b/compiler/generator_go.c
@@ -1218,7 +1218,8 @@ static void generate_grouping_table(struct generator * g, struct grouping * q) {
 static void generate_groupings(struct generator * g) {
     struct grouping * q;
     for (q = g->analyser->groupings; q; q = q->next) {
-        generate_grouping_table(g, q);
+        if (q->name->used)
+            generate_grouping_table(g, q);
     }
 }
 

--- a/compiler/generator_java.c
+++ b/compiler/generator_java.c
@@ -1229,7 +1229,8 @@ static void generate_grouping_table(struct generator * g, struct grouping * q) {
 static void generate_groupings(struct generator * g) {
     struct grouping * q;
     for (q = g->analyser->groupings; q; q = q->next) {
-        generate_grouping_table(g, q);
+        if (q->name->used)
+            generate_grouping_table(g, q);
     }
 }
 

--- a/compiler/generator_js.c
+++ b/compiler/generator_js.c
@@ -1234,7 +1234,8 @@ static void generate_grouping_table(struct generator * g, struct grouping * q) {
 static void generate_groupings(struct generator * g) {
     struct grouping * q;
     for (q = g->analyser->groupings; q; q = q->next) {
-        generate_grouping_table(g, q);
+        if (q->name->used)
+            generate_grouping_table(g, q);
     }
 }
 

--- a/compiler/generator_pascal.c
+++ b/compiler/generator_pascal.c
@@ -1336,7 +1336,8 @@ static void generate_grouping_table(struct generator * g, struct grouping * q) {
 static void generate_groupings(struct generator * g) {
     struct grouping * q;
     for (q = g->analyser->groupings; q; q = q->next) {
-        generate_grouping_table(g, q);
+        if (q->name->used)
+            generate_grouping_table(g, q);
     }
 }
 

--- a/compiler/generator_python.c
+++ b/compiler/generator_python.c
@@ -1224,7 +1224,8 @@ static void generate_grouping_table(struct generator * g, struct grouping * q) {
 static void generate_groupings(struct generator * g) {
     struct grouping * q;
     for (q = g->analyser->groupings; q; q = q->next) {
-        generate_grouping_table(g, q);
+        if (q->name->used)
+            generate_grouping_table(g, q);
     }
 }
 

--- a/compiler/generator_rust.c
+++ b/compiler/generator_rust.c
@@ -1228,7 +1228,8 @@ static void generate_grouping_table(struct generator * g, struct grouping * q) {
 static void generate_groupings(struct generator * g) {
     struct grouping * q;
     for (q = g->analyser->groupings; q; q = q->next) {
-        generate_grouping_table(g, q);
+        if (q->name->used)
+            generate_grouping_table(g, q);
     }
 }
 

--- a/compiler/header.h
+++ b/compiler/header.h
@@ -161,6 +161,7 @@ struct name {
     byte used_in_among;         /* Function used in among? */
     byte value_used;            /* (For variables) is its value ever used? */
     byte initialised;           /* (For variables) is it ever initialised? */
+    byte used_in_definition;    /* (grouping) used in grouping definition? */
     struct node * used;         /* First use, or NULL if not used */
     struct name * local_to;     /* Local to one routine/external */
     int declaration_line_number;/* Line number of declaration */

--- a/compiler/header.h
+++ b/compiler/header.h
@@ -204,7 +204,6 @@ struct among {
 struct grouping {
 
     struct grouping * next;
-    int number;               /* groupings are numbered 0, 1, 2 ... */
     symbol * b;               /* the characters of this group */
     int largest_ch;           /* character with max code */
     int smallest_ch;          /* character with min code */


### PR DESCRIPTION
Together these commits smooth the way for defining groupings that you only intend to use to define other groupings, e.g. consider this if `v2` isn't otherwise used:

```
define v1 as 'ae'
define v2 as 'iou'
define v as v1 + v2
```

Currently we warn that `v2` is defined but not used, but that's confusing and unhelpful.
