### PR TITLE
Eliminate variables whose values are never used

### DIFF
--- a/compiler/analyser.c
+++ b/compiler/analyser.c
@@ -287,7 +287,9 @@ handle_as_name:
                     p->b = copy_b(t->b);
                     p->type = type;
                     p->mode = -1; /* routines, externals */
-                    p->count = a->name_count[type];
+                    /* We defer assigning counts until after we've eliminated
+                     * variables whose values are never used. */
+                    p->count = -1;
                     p->referenced = false;
                     p->used_in_among = false;
                     p->used = 0;
@@ -298,7 +300,6 @@ handle_as_name:
                     p->grouping = 0;
                     p->definition = 0;
                     p->declaration_line_number = t->line_number;
-                    a->name_count[type]++;
                     p->next = a->names;
                     a->names = p;
                     if (token != c_name) {
@@ -1189,6 +1190,38 @@ static void read_program_(struct analyser * a, int terminator) {
     }
 }
 
+static void remove_dead_assignments(struct node * p, struct name * q) {
+    if (p->name == q) {
+        switch (p->type) {
+            case c_assignto:
+            case c_sliceto:
+            case c_mathassign:
+            case c_plusassign:
+            case c_minusassign:
+            case c_multiplyassign:
+            case c_divideassign:
+            case c_setmark:
+            case c_set:
+            case c_unset:
+            case c_dollar:
+                /* c_true is a no-op. */
+                p->type = c_true;
+                break;
+            default:
+                /* There are no read accesses to this variable, so any
+                 * references must be assignments.
+                 */
+                fprintf(stderr, "Unhandled type of dead assignment via %s\n",
+                        name_of_token(p->type));
+                exit(1);
+        }
+    }
+    if (p->AE) remove_dead_assignments(p->AE, q);
+    if (p->left) remove_dead_assignments(p->left, q);
+    if (p->aux) remove_dead_assignments(p->aux, q);
+    if (p->right) remove_dead_assignments(p->right, q);
+}
+
 extern void read_program(struct analyser * a) {
     read_program_(a, -1);
     {
@@ -1208,6 +1241,7 @@ extern void read_program(struct analyser * a) {
 
     if (a->tokeniser->error_count == 0) {
         struct name * q = a->names;
+        struct name ** ptr = &(a->names);
         while (q) {
             if (!q->referenced) {
                 fprintf(stderr, "%s:%d: warning: %s '",
@@ -1221,6 +1255,9 @@ extern void read_program(struct analyser * a) {
                     fprintf(stderr, "' declared but not defined\n");
                 } else {
                     fprintf(stderr, "' defined but not used\n");
+                    q = q->next;
+                    *ptr = q;
+                    continue;
                 }
             } else if (q->type == t_routine || q->type == t_grouping) {
                 /* It's OK to define a grouping but only use it to define other
@@ -1256,8 +1293,24 @@ extern void read_program(struct analyser * a) {
                         name_of_name_type(q->type));
                 report_b(stderr, q->b);
                 fprintf(stderr, "' is set but never used\n");
+                remove_dead_assignments(a->program, q);
+                q = q->next;
+                *ptr = q;
+                continue;
             }
+            ptr = &(q->next);
             q = q->next;
+        }
+
+        {
+            /* Now we've eliminated variables whose values are never used we
+             * can number the variables, which is used by some generators.
+             */
+            int * name_count = a->name_count;
+            struct name * n;
+            for (n = a->names; n; n = n->next) {
+                n->count = name_count[n->type]++;
+            }
         }
     }
 }


### PR DESCRIPTION
They no longer have corresponding member variables, etc, and
no code is generated for any assignments to them.