### PR TITLE
Pass -Wl,-dead_strip,-bind_at_load on macOS

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -153,6 +153,14 @@ JAVA_RUNTIME_CLASSES=$(JAVARUNTIME_SOURCES:.java=.class)
 CFLAGS=-O2 -W -Wall -Wmissing-prototypes -Wmissing-declarations
 CPPFLAGS=-Iinclude
 
+# pass -dead_strip and -bind_at_load on macOS to shave some binary size
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+CFLAGS=-O2 -W -Wall -Wmissing-prototypes -Wmissing-declarations
+CPPFLAGS=-Iinclude
+LDFLAGS=-Wl,-dead_strip,-bind_at_load
+endif
+
 all: snowball libstemmer.o stemwords $(C_OTHER_SOURCES) $(C_OTHER_HEADERS) $(C_OTHER_OBJECTS)
 
 clean:


### PR DESCRIPTION
From `man ld`:
```
-dead_strip
                 Remove functions and data that are unreachable by the entry point or exported symbols.
```
```
-bind_at_load
                 Sets a bit in the mach header of the resulting binary which tells dyld to bind all symbols when the binary is loaded,
                 rather than lazily.
```
Before:
```
% wc -c snowball 
 211964 snowball

% wc -c stemwords
 757096 stemwords
```
After:
```
% wc -c snowball 
 211852 snowball

% wc -c stemwords 
 756776 stemwords
```