### PR TITLE
[python] Remove the classifiers blacklist

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -39,12 +39,7 @@ classifiers = [
     'License :: OSI Approved :: BSD License'
 ]
 
-for lang in langs:
-    lang_titlecase = lang.title()
-    # Only classifiers listed in https://pypi.org/classifiers/ are allowed
-    if lang_titlecase not in ('Basque', 'Irish', 'Nepali'):
-        classifiers.append('Natural Language :: ' + lang_titlecase)
-
+classifiers.extend('Natural Language :: ' + lang.title() for lang in langs)
 
 classifiers.extend([
     'Operating System :: OS Independent',


### PR DESCRIPTION
Basque, Irish and Nepali were added as possible natural languages to PyPI. See pypa/pypi-support#138.