### PR TITLE
fix GNUmakefile dependencies on Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,11 +81,15 @@ before_install:
   # CI tested easily.
   #
   # If that fails, just use the standard snowball-data repo's default branch.
+  #
+  # We currently skip this step on Microsoft Windows as checking out the
+  # data repo seems to stall indefinitely, so for now we just do the build
+  # there and don't run any tests.
   - GH_BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
   - GH_REPO_SLUG=${TRAVIS_PULL_REQUEST_SLUG:-$TRAVIS_REPO_SLUG}
   - GH_REPO_URL=https://github.com/${GH_REPO_SLUG%%/*}/snowball-data.git
-  - echo "Trying branch $GH_BRANCH from $GH_REPO_URL"
-  - git clone --depth=1 -b "$GH_BRANCH" "$GH_REPO_URL" || git clone --depth=1 https://github.com/snowballstem/snowball-data.git
+  - test "$TRAVIS_OS_NAME" = windows || echo "Trying branch $GH_BRANCH from $GH_REPO_URL"
+  - test "$TRAVIS_OS_NAME" = windows || git clone --depth=1 -b "$GH_BRANCH" "$GH_REPO_URL" || git clone --depth=1 https://github.com/snowballstem/snowball-data.git
   - |-
       case $TRAVIS_OS_NAME in
         windows)

--- a/.travis.yml
+++ b/.travis.yml
@@ -105,7 +105,7 @@ before_install:
           ## Install more MSYS2 packages from https://packages.msys2.org/base here
           taskkill //IM gpg-agent.exe //F  # https://travis-ci.community/t/4967
           export PATH=/C/tools/msys64/mingw64/bin:/C/tools/msys64/usr/bin:$PATH
-          export MAKE=make  # so that Autotools can find it
+          export MAKE=mingw32-make
           ;;
       esac
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: minimal
 dist: trusty
 matrix:
   include:
+    - os: windows
+      language: c
     - language: c
       compiler: gcc
       env: c_tests=y cc_append=' -std=c90 -Wdeclaration-after-statement -Werror'
@@ -72,6 +74,25 @@ before_install:
   - GH_REPO_URL=https://github.com/${GH_REPO_SLUG%%/*}/snowball-data.git
   - echo "Trying branch $GH_BRANCH from $GH_REPO_URL"
   - git clone --depth=1 -b "$GH_BRANCH" "$GH_REPO_URL" || git clone --depth=1 https://github.com/snowballstem/snowball-data.git
+  - |-
+      case $TRAVIS_OS_NAME in
+        windows)
+          [[ ! -f C:/tools/msys64/msys2_shell.cmd ]] && rm -rf C:/tools/msys64
+          choco uninstall -y mingw
+          choco upgrade --no-progress -y msys2
+          export msys2='cmd //C RefreshEnv.cmd '
+          export msys2+='& set MSYS=winsymlinks:nativestrict '
+          export msys2+='& C:\\tools\\msys64\\msys2_shell.cmd -defterm -no-start'
+          export mingw64="$msys2 -mingw64 -full-path -here -c "\"\$@"\" --"
+          export msys2+=" -msys2 -c "\"\$@"\" --"
+          $msys2 pacman --sync --noconfirm --needed mingw-w64-x86_64-toolchain
+          ## Install more MSYS2 packages from https://packages.msys2.org/base here
+          taskkill //IM gpg-agent.exe //F  # https://travis-ci.community/t/4967
+          export PATH=/C/tools/msys64/mingw64/bin:/C/tools/msys64/usr/bin:$PATH
+          export MAKE=make  # so that Autotools can find it
+          ;;
+      esac
+
 script:
   - make CC="${CC:-gcc}$cc_append"
   - test -z "$c_tests" || make check CC="${CC:-gcc}$cc_append" STEMMING_DATA=snowball-data

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -4,6 +4,13 @@
 # which hard-code it.
 SNOWBALL_VERSION = 2.0.0
 
+ifeq ($(OS),Windows_NT)
+  EXEEXT = .exe
+endif
+SNOWBALLPROG = snowball$(EXEEXT)
+STEMWORDS_PROG = stemwords$(EXEEXT)
+CSHARP_STEMWORDS_PROG = csharp_stemwords$(EXEEXT)
+
 c_src_dir = src_c
 
 JAVAC ?= javac
@@ -153,12 +160,12 @@ JAVA_RUNTIME_CLASSES=$(JAVARUNTIME_SOURCES:.java=.class)
 CFLAGS=-O2 -W -Wall -Wmissing-prototypes -Wmissing-declarations
 CPPFLAGS=-Iinclude
 
-all: snowball libstemmer.o stemwords $(C_OTHER_SOURCES) $(C_OTHER_HEADERS) $(C_OTHER_OBJECTS)
+all: $(SNOWBALLPROG) libstemmer.o $(STEMWORDS_PROG) $(C_OTHER_SOURCES) $(C_OTHER_HEADERS) $(C_OTHER_OBJECTS)
 
 clean:
 	rm -f $(COMPILER_OBJECTS) $(RUNTIME_OBJECTS) \
-	      $(LIBSTEMMER_OBJECTS) $(LIBSTEMMER_UTF8_OBJECTS) $(STEMWORDS_OBJECTS) snowball \
-	      libstemmer.o stemwords \
+	      $(LIBSTEMMER_OBJECTS) $(LIBSTEMMER_UTF8_OBJECTS) $(STEMWORDS_OBJECTS) $(SNOWBALLPROG) \
+	      libstemmer.o $(STEMWORDS_PROG) \
               libstemmer/modules.h \
               libstemmer/modules_utf8.h \
 	      $(C_LIB_SOURCES) $(C_LIB_HEADERS) $(C_LIB_OBJECTS) \
@@ -177,7 +184,7 @@ clean:
 	-rmdir $(python_output_dir)
 	-rmdir $(js_output_dir)
 
-snowball: $(COMPILER_OBJECTS)
+$(SNOWBALLPROG): $(COMPILER_OBJECTS)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^
 
 $(COMPILER_OBJECTS): $(COMPILER_HEADERS)
@@ -199,10 +206,10 @@ libstemmer/libstemmer.o: libstemmer/modules.h $(C_LIB_HEADERS)
 libstemmer.o: libstemmer/libstemmer.o $(RUNTIME_OBJECTS) $(C_LIB_OBJECTS)
 	$(AR) -cru $@ $^
 
-stemwords: $(STEMWORDS_OBJECTS) libstemmer.o
+$(STEMWORDS_PROG): $(STEMWORDS_OBJECTS) libstemmer.o
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^
 
-csharp_stemwords: $(CSHARP_STEMWORDS_SOURCES) $(CSHARP_RUNTIME_SOURCES) $(CSHARP_SOURCES)
+$(CSHARP_STEMWORDS_PROG): $(CSHARP_STEMWORDS_SOURCES) $(CSHARP_RUNTIME_SOURCES) $(CSHARP_SOURCES)
 	$(MCS) -unsafe -target:exe -out:$@ $(CSHARP_STEMWORDS_SOURCES) $(CSHARP_RUNTIME_SOURCES) $(CSHARP_SOURCES)
 
 pascal/stemwords.dpr: pascal/stemwords-template.dpr libstemmer/modules.txt
@@ -211,28 +218,28 @@ pascal/stemwords.dpr: pascal/stemwords-template.dpr libstemmer/modules.txt
 pascal/stemwords: $(PASCAL_STEMWORDS_SOURCES) $(PASCAL_RUNTIME_SOURCES) $(PASCAL_SOURCES)
 	$(FPC) -o$@ -Mdelphi $(PASCAL_STEMWORDS_SOURCES)
 
-$(c_src_dir)/stem_UTF_8_%.c $(c_src_dir)/stem_UTF_8_%.h: algorithms/%.sbl snowball
+$(c_src_dir)/stem_UTF_8_%.c $(c_src_dir)/stem_UTF_8_%.h: algorithms/%.sbl $(SNOWBALLPROG)
 	@mkdir -p $(c_src_dir)
 	@l=`echo "$<" | sed 's!\(.*\)\.sbl$$!\1!;s!^.*/!!'`; \
 	o="$(c_src_dir)/stem_UTF_8_$${l}"; \
 	echo "./snowball $< -o $${o} -eprefix $${l}_UTF_8_ -r ../runtime -u"; \
 	./snowball $< -o $${o} -eprefix $${l}_UTF_8_ -r ../runtime -u
 
-$(c_src_dir)/stem_KOI8_R_%.c $(c_src_dir)/stem_KOI8_R_%.h: algorithms/%.sbl snowball
+$(c_src_dir)/stem_KOI8_R_%.c $(c_src_dir)/stem_KOI8_R_%.h: algorithms/%.sbl $(SNOWBALLPROG)
 	@mkdir -p $(c_src_dir)
 	@l=`echo "$<" | sed 's!\(.*\)\.sbl$$!\1!;s!^.*/!!'`; \
 	o="$(c_src_dir)/stem_KOI8_R_$${l}"; \
 	echo "./snowball charsets/KOI8-R.sbl $< -o $${o} -eprefix $${l}_KOI8_R_ -r ../runtime"; \
 	./snowball charsets/KOI8-R.sbl $< -o $${o} -eprefix $${l}_KOI8_R_ -r ../runtime
 
-$(c_src_dir)/stem_ISO_8859_1_%.c $(c_src_dir)/stem_ISO_8859_1_%.h: algorithms/%.sbl snowball
+$(c_src_dir)/stem_ISO_8859_1_%.c $(c_src_dir)/stem_ISO_8859_1_%.h: algorithms/%.sbl $(SNOWBALLPROG)
 	@mkdir -p $(c_src_dir)
 	@l=`echo "$<" | sed 's!\(.*\)\.sbl$$!\1!;s!^.*/!!'`; \
 	o="$(c_src_dir)/stem_ISO_8859_1_$${l}"; \
 	echo "./snowball $< -o $${o} -eprefix $${l}_ISO_8859_1_ -r ../runtime"; \
 	./snowball $< -o $${o} -eprefix $${l}_ISO_8859_1_ -r ../runtime
 
-$(c_src_dir)/stem_ISO_8859_2_%.c $(c_src_dir)/stem_ISO_8859_2_%.h: algorithms/%.sbl snowball
+$(c_src_dir)/stem_ISO_8859_2_%.c $(c_src_dir)/stem_ISO_8859_2_%.h: algorithms/%.sbl $(SNOWBALLPROG)
 	@mkdir -p $(c_src_dir)
 	@l=`echo "$<" | sed 's!\(.*\)\.sbl$$!\1!;s!^.*/!!'`; \
 	o="$(c_src_dir)/stem_ISO_8859_2_$${l}"; \
@@ -242,14 +249,14 @@ $(c_src_dir)/stem_ISO_8859_2_%.c $(c_src_dir)/stem_ISO_8859_2_%.h: algorithms/%.
 $(c_src_dir)/stem_%.o: $(c_src_dir)/stem_%.c $(c_src_dir)/stem_%.h
 	$(CC) $(CFLAGS) $(CPPFLAGS) -c -o $@ $<
 
-$(java_src_dir)/%Stemmer.java: algorithms/%.sbl snowball
+$(java_src_dir)/%Stemmer.java: algorithms/%.sbl $(SNOWBALLPROG)
 	@mkdir -p $(java_src_dir)
 	@l=`echo "$<" | sed 's!\(.*\)\.sbl$$!\1!;s!^.*/!!'`; \
 	o="$(java_src_dir)/$${l}Stemmer"; \
 	echo "./snowball $< -j -o $${o} -p org.tartarus.snowball.SnowballStemmer"; \
 	./snowball $< -j -o $${o} -p org.tartarus.snowball.SnowballStemmer
 
-$(csharp_src_dir)/%Stemmer.generated.cs: algorithms/%.sbl snowball
+$(csharp_src_dir)/%Stemmer.generated.cs: algorithms/%.sbl $(SNOWBALLPROG)
 	@mkdir -p $(csharp_src_dir)
 	@l=`echo "$<" | sed 's!\(.*\)\.sbl$$!\1!;s!^.*/!!'`; \
 	t=`echo "$${l}" | sed 's/.*/\L&/; s/[a-z]*/\u&/g'`; \
@@ -257,7 +264,7 @@ $(csharp_src_dir)/%Stemmer.generated.cs: algorithms/%.sbl snowball
 	echo "./snowball $< -cs -o $${o}"; \
 	./snowball $< -cs -o $${o}
 
-$(pascal_src_dir)/%Stemmer.pas: algorithms/%.sbl snowball
+$(pascal_src_dir)/%Stemmer.pas: algorithms/%.sbl $(SNOWBALLPROG)
 	@mkdir -p $(pascal_src_dir)
 	@l=`echo "$<" | sed 's!\(.*\)\.sbl$$!\1!;s!^.*/!!'`; \
 	t=`echo "$${l}" | sed 's/.*/\L&/; s/[a-z]*/\u&/g'`; \
@@ -265,7 +272,7 @@ $(pascal_src_dir)/%Stemmer.pas: algorithms/%.sbl snowball
 	echo "./snowball $< -pascal -o $${o}"; \
 	./snowball $< -pascal -o $${o}
 
-$(python_output_dir)/%_stemmer.py: algorithms/%.sbl snowball
+$(python_output_dir)/%_stemmer.py: algorithms/%.sbl $(SNOWBALLPROG)
 	@mkdir -p $(python_output_dir)
 	@l=`echo "$<" | sed 's!\(.*\)\.sbl$$!\1!;s!^.*/!!'`; \
 	o="$(python_output_dir)/$${l}_stemmer"; \
@@ -276,7 +283,7 @@ $(python_output_dir)/__init__.py: libstemmer/modules.txt
 	@mkdir -p $(python_output_dir)
 	$(python) python/create_init.py $(python_output_dir)
 
-$(rust_src_dir)/%_stemmer.rs: algorithms/%.sbl snowball
+$(rust_src_dir)/%_stemmer.rs: algorithms/%.sbl $(SNOWBALLPROG)
 	@mkdir -p $(rust_src_dir)
 	@l=`echo "$<" | sed 's!\(.*\)\.sbl$$!\1!;s!^.*/!!'`; \
 	o="$(rust_src_dir)/$${l}_stemmer"; \
@@ -287,7 +294,7 @@ $(go_src_main_dir)/stemwords/algorithms.go:
 	@echo "Generating algorithms.go"
 	@cd go/stemwords && go generate
 
-$(go_src_dir)/%_stemmer.go: algorithms/%.sbl snowball
+$(go_src_dir)/%_stemmer.go: algorithms/%.sbl $(SNOWBALLPROG)
 	@l=`echo "$<" | sed 's!\(.*\)\.sbl$$!\1!;s!^.*/!!'`; \
 	o="$(go_src_dir)/$${l}/$${l}_stemmer"; \
 	mkdir -p $(go_src_dir)/$${l}
@@ -300,7 +307,7 @@ $(go_src_dir)/%_stemmer.go: algorithms/%.sbl snowball
 	echo "$(gofmt) -s -w $(go_src_dir)/$${l}/$${l}_stemmer.go"; \
 	$(gofmt) -s -w $(go_src_dir)/$${l}/$${l}_stemmer.go
 
-$(js_output_dir)/%-stemmer.js: algorithms/%.sbl snowball
+$(js_output_dir)/%-stemmer.js: algorithms/%.sbl $(SNOWBALLPROG)
 	@mkdir -p $(js_output_dir)
 	@l=`echo "$<" | sed 's!\(.*\)\.sbl$$!\1!;s!^.*/!!'`; \
 	o="$(js_output_dir)/$${l}-stemmer"; \
@@ -369,15 +376,18 @@ dist_libstemmer_c: \
         cp -a libstemmer/mkinc.mak libstemmer/mkinc_utf8.mak $${dest}/ && \
 	cp -a $(COMMON_FILES) $${dest} && \
 	echo 'include mkinc.mak' >> $${dest}/Makefile && \
+	echo 'ifeq ($$(OS),Windows_NT)' >> $${dest}/Makefile && \
+	echo 'EXEEXT=.exe' >> $${dest}/Makefile && \
+	echo 'endif' >> $${dest}/Makefile && \
 	echo 'CFLAGS=-O2' >> $${dest}/Makefile && \
 	echo 'CPPFLAGS=-Iinclude' >> $${dest}/Makefile && \
-	echo 'all: libstemmer.o stemwords' >> $${dest}/Makefile && \
+	echo 'all: libstemmer.o stemwords$$(EXEEXT)' >> $${dest}/Makefile && \
 	echo 'libstemmer.o: $$(snowball_sources:.c=.o)' >> $${dest}/Makefile && \
 	echo '	$$(AR) -cru $$@ $$^' >> $${dest}/Makefile && \
-	echo 'stemwords: examples/stemwords.o libstemmer.o' >> $${dest}/Makefile && \
+	echo 'stemwords$$(EXEEXT): examples/stemwords.o libstemmer.o' >> $${dest}/Makefile && \
 	echo '	$$(CC) $$(CFLAGS) -o $$@ $$^' >> $${dest}/Makefile && \
 	echo 'clean:' >> $${dest}/Makefile && \
-	echo '	rm -f stemwords *.o $(c_src_dir)/*.o examples/*.o runtime/*.o libstemmer/*.o' >> $${dest}/Makefile && \
+	echo '	rm -f stemwords$$(EXEEXT) *.o $(c_src_dir)/*.o examples/*.o runtime/*.o libstemmer/*.o' >> $${dest}/Makefile && \
 	(cd dist && tar zcf $${destname}.tgz $${destname}) && \
 	rm -rf $${dest}
 
@@ -473,12 +483,12 @@ check_koi8r: $(KOI8_R_algorithms:%=check_koi8r_%)
 STEMMING_DATA ?= ../snowball-data
 STEMMING_DATA_ABS := $(abspath $(STEMMING_DATA))
 
-check_utf8_%: $(STEMMING_DATA)/% stemwords
+check_utf8_%: $(STEMMING_DATA)/% $(STEMWORDS_PROG)
 	@echo "Checking output of `echo $<|sed 's!.*/!!'` stemmer with UTF-8"
 	@if test -f '$</voc.txt.gz' ; then \
-	  gzip -dc '$</voc.txt.gz'|./stemwords -c UTF_8 -l `echo $<|sed 's!.*/!!'` -o tmp.txt; \
+	  gzip -dc '$</voc.txt.gz'|./$(STEMWORDS_PROG) -c UTF_8 -l `echo $<|sed 's!.*/!!'` -o tmp.txt; \
 	else \
-	  ./stemwords -c UTF_8 -l `echo $<|sed 's!.*/!!'` -i $</voc.txt -o tmp.txt; \
+	  ./$(STEMWORDS_PROG) -c UTF_8 -l `echo $<|sed 's!.*/!!'` -i $</voc.txt -o tmp.txt; \
 	fi
 	@if test -f '$</output.txt.gz' ; then \
 	  gzip -dc '$</output.txt.gz'|diff -u - tmp.txt; \
@@ -487,7 +497,7 @@ check_utf8_%: $(STEMMING_DATA)/% stemwords
 	fi
 	@rm tmp.txt
 
-check_iso_8859_1_%: $(STEMMING_DATA)/% stemwords
+check_iso_8859_1_%: $(STEMMING_DATA)/% $(STEMWORDS_PROG)
 	@echo "Checking output of `echo $<|sed 's!.*/!!'` stemmer with ISO_8859_1"
 	@$(ICONV) -fUTF8 -tISO8859-1 '$</voc.txt' |\
 	    ./stemwords -c ISO_8859_1 -l `echo $<|sed 's!.*/!!'` -o tmp.txt
@@ -495,7 +505,7 @@ check_iso_8859_1_%: $(STEMMING_DATA)/% stemwords
 	    diff -u - tmp.txt
 	@rm tmp.txt
 
-check_iso_8859_2_%: $(STEMMING_DATA)/% stemwords
+check_iso_8859_2_%: $(STEMMING_DATA)/% $(STEMWORDS_PROG)
 	@echo "Checking output of `echo $<|sed 's!.*/!!'` stemmer with ISO_8859_2"
 	@$(ICONV) -fUTF8 -tISO8859-2 '$</voc.txt' |\
 	    ./stemwords -c ISO_8859_2 -l `echo $<|sed 's!.*/!!'` -o tmp.txt
@@ -503,7 +513,7 @@ check_iso_8859_2_%: $(STEMMING_DATA)/% stemwords
 	    diff -u - tmp.txt
 	@rm tmp.txt
 
-check_koi8r_%: $(STEMMING_DATA)/% stemwords
+check_koi8r_%: $(STEMMING_DATA)/% $(STEMWORDS_PROG)
 	@echo "Checking output of `echo $<|sed 's!.*/!!'` stemmer with KOI8R"
 	@$(ICONV) -fUTF8 -tKOI8-R '$</voc.txt' |\
 	    ./stemwords -c KOI8_R -l `echo $<|sed 's!.*/!!'` -o tmp.txt
@@ -534,7 +544,7 @@ check_java_%: $(STEMMING_DATA_ABS)/%
 	fi
 	@rm tmp.txt
 
-check_csharp: csharp_stemwords
+check_csharp: $(CSHARP_STEMWORDS_PROG)
 	$(MAKE) do_check_csharp
 
 do_check_csharp: $(libstemmer_algorithms:%=check_csharp_%)
@@ -543,9 +553,9 @@ check_csharp_%: $(STEMMING_DATA_ABS)/%
 	@echo "Checking output of `echo $<|sed 's!.*/!!'` stemmer for C#"
 	@if test -f '$</voc.txt.gz' ; then \
 	  gzip -dc '$</voc.txt.gz' |\
-	    $(MONO) csharp_stemwords -l `echo $<|sed 's!.*/!!'` -i /dev/stdin -o tmp.txt; \
+	    $(MONO) $(CSHARP_STEMWORDS_PROG) -l `echo $<|sed 's!.*/!!'` -i /dev/stdin -o tmp.txt; \
 	else \
-	  $(MONO) csharp_stemwords -l `echo $<|sed 's!.*/!!'` -i $</voc.txt -o tmp.txt; \
+	  $(MONO) $(CSHARP_STEMWORDS_PROG) -l `echo $<|sed 's!.*/!!'` -i $</voc.txt -o tmp.txt; \
 	fi
 	@if test -f '$</output.txt.gz' ; then \
 	  gzip -dc '$</output.txt.gz'|diff -u - tmp.txt; \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -411,7 +411,8 @@ dist_libstemmer_c: \
 	echo 'EXEEXT=.exe' >> $${dest}/Makefile && \
 	echo 'endif' >> $${dest}/Makefile && \
 	echo 'CFLAGS=-O2' >> $${dest}/Makefile && \
-	echo 'CPPFLAGS=-Iinclude' >> $${dest}/Makefile && \	echo 'all: libstemmer.a stemwords$$(EXEEXT)' >> $${dest}/Makefile && \
+	echo 'CPPFLAGS=-Iinclude' >> $${dest}/Makefile && \
+	echo 'all: libstemmer.a stemwords$$(EXEEXT)' >> $${dest}/Makefile && \
 	echo 'libstemmer.a: $$(snowball_sources:.c=.o)' >> $${dest}/Makefile && \
 	echo '	$$(AR) -cru $$@ $$^' >> $${dest}/Makefile && \
 	echo 'stemwords$$(EXEEXT): examples/stemwords.o libstemmer.a' >> $${dest}/Makefile && \


### PR DESCRIPTION
On Windows platforms executables have the extension '.exe'.  Compilers
like gcc append the extension if not provided in the '-o' flag.  A Windows
platform can easily be recognized by checking if the environment variable
OS equals 'Windows_NT'.

This commit adds the extension of built executables to prerequisites of
GNUmakefile rules, such that make can figure out the dependencies.

NOTE: Extensions are not added to executable names when called by a shell
(e.g., cmd, sh) which are usually able to call the executable even when
the name is provided without extension.