### PR TITLE
Basic optimizations for C# stemmer output

### DIFF
--- a/compiler/generator_csharp.c
+++ b/compiler/generator_csharp.c
@@ -1188,19 +1188,10 @@ static void generate_class_end(struct generator * g) {
 
 static void generate_among_declaration(struct generator * g, struct among * x) {
 
-    g->I[0] = x->number;
-    g->I[1] = x->literalstring_count;
-
-    w(g, "~Mprivate readonly Among[] a_~I0;~N");
-}
-
-static void generate_among_table(struct generator * g, struct among * x) {
-
     struct amongvec * v = x->b;
-
     g->I[0] = x->number;
 
-    w(g, "~Ma_~I0 = new[] ~N~M{~N~+");
+    w(g, "~Mprivate static readonly Among[] a_~I0 = new[] ~N~M{~N~+");
     {
         int i;
         for (i = 0; i < x->literalstring_count; i++) {
@@ -1224,26 +1215,11 @@ static void generate_among_table(struct generator * g, struct among * x) {
 static void generate_amongs(struct generator * g) {
     struct among * x;
 
-    /* Generate declarations. */
     x = g->analyser->amongs;
     while (x != 0) {
         generate_among_declaration(g, x);
         x = x->next;
     }
-
-    w(g, "~N");
-    w(g, "~M/// <summary>~N");
-    w(g, "~M///   Initializes a new instance of the <see cref=\"~n\"/> class.~N");
-    w(g, "~M/// </summary>~N");
-    w(g, "~M/// ~N");
-    w(g, "~Mpublic ~n()~N~{");
-    x = g->analyser->amongs;
-    while (x != 0) {
-        generate_among_table(g, x);
-        x = x->next;
-    }
-
-    w(g, "~}~N~N");
 }
 
 static void generate_grouping_table(struct generator * g, struct grouping * q) {

--- a/compiler/generator_csharp.c
+++ b/compiler/generator_csharp.c
@@ -1186,12 +1186,14 @@ static void generate_class_end(struct generator * g) {
     w(g, "~N");
 }
 
-static void generate_among_declaration(struct generator * g, struct among * x) {
+static void generate_among_table(struct generator * g, struct among * x, const char * type) {
 
     struct amongvec * v = x->b;
-    g->I[0] = x->number;
 
-    w(g, "~Mprivate static readonly Among[] a_~I0 = new[] ~N~M{~N~+");
+    g->I[0] = x->number;
+    g->S[0] = type;
+    w(g, "~M~S0a_~I0 = new[] ~N~M{~N~+");
+
     {
         int i;
         for (i = 0; i < x->literalstring_count; i++) {
@@ -1213,13 +1215,39 @@ static void generate_among_declaration(struct generator * g, struct among * x) {
 }
 
 static void generate_amongs(struct generator * g) {
-    struct among * x;
+    int amongs_with_functions = 0;
+    struct among * x = g->analyser->amongs;
 
-    x = g->analyser->amongs;
     while (x != 0) {
-        generate_among_declaration(g, x);
+        if (x->function_count) {
+            g->I[0] = x->number;
+            g->I[1] = x->literalstring_count;
+
+            w(g, "~Mprivate readonly Among[] a_~I0;~N");
+            ++amongs_with_functions;
+        } else {
+            generate_among_table(g, x, "private static readonly Among[] ");
+        }
         x = x->next;
     }
+    w(g, "~N");
+
+    if (!amongs_with_functions) return;
+
+    w(g, "~M/// <summary>~N");
+    w(g, "~M///   Initializes a new instance of the <see cref=\"~n\"/> class.~N");
+    w(g, "~M/// </summary>~N");
+    w(g, "~M/// ~N");
+    w(g, "~Mpublic ~n()~N~{");
+    x = g->analyser->amongs;
+    while (x != 0) {
+        if (x->function_count) {
+            generate_among_table(g, x, "");
+        }
+        x = x->next;
+    }
+
+    w(g, "~}~N~N");
 }
 
 static void generate_grouping_table(struct generator * g, struct grouping * q) {

--- a/compiler/generator_csharp.c
+++ b/compiler/generator_csharp.c
@@ -1228,7 +1228,7 @@ static void generate_grouping_table(struct generator * g, struct grouping * q) {
 
     g->V[0] = q->name;
 
-    w(g, "~Mprivate static string ~V0 = ");
+    w(g, "~Mprivate const string ~V0 = ");
     write_literal_string(g, b);
     w(g, ";~N");
 }


### PR DESCRIPTION
This moves the among values to static, defined at their declaration. Additionally sets the grouping declarations to be constant rather than static.

Related to discussions in #146 