### PR TITLE
Merge Czech stemmer

### DIFF
--- a/CzechStemmerLight.java
+++ b/CzechStemmerLight.java
@@ -184,7 +184,7 @@ public class CzechStemmerLight {
 				    buffer.substring( len-2,len).equals("\u00e9m")||    //-ém
 				    buffer.substring( len-2,len).equals("\u00edm")){   //-ím
 			
-			            buffer.delete( len- 2 , len);
+			            buffer.delete( len- 1 , len);
 			            palatalise(buffer);
 			            return;
 			        }

--- a/CzechStemmerLight.java
+++ b/CzechStemmerLight.java
@@ -1,0 +1,297 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * @author Dolamic Ljiljana  University of Neuchatel
+ *
+ * Czech stemmer-removes case endings form nouns and adjectives, possessive adj.
+ * endings from names
+ * and takes care of palatalisation 
+ */
+public class CzechStemmerLight {
+	
+	/**
+	 * A buffer of the current word being stemmed
+	 */
+	private StringBuffer sb=new StringBuffer();
+
+	
+	/**
+	 * Default constructor
+	 */
+    public CzechStemmerLight(){} // constructor
+    
+	public String stem(String input){
+		
+		//
+		input=input.toLowerCase();
+
+		//reset string buffer
+		sb.delete(0,sb.length());
+		sb.insert(0,input);
+
+		// stemming...
+		//removes case endings from nouns and adjectives
+		removeCase(sb);
+
+		//removes possessive endings from names -ov- and -in-
+		removePossessives(sb);
+
+		String result = sb.toString();
+		
+
+		return result;
+	}
+	private void palatalise(StringBuffer buffer){
+		int len=buffer.length();
+		
+		if( buffer.substring( len- 2 ,len).equals("ci")||
+		    buffer.substring( len- 2 ,len).equals("ce")||		
+		    buffer.substring( len- 2 ,len).equals("\u010di")||  //-či
+		    buffer.substring( len- 2 ,len).equals("\u010de")){  //-če
+				
+		    buffer.replace(len- 2 ,len, "k");
+		    return;
+		}
+		if( buffer.substring( len- 2 ,len).equals("zi")||
+		    buffer.substring( len- 2 ,len).equals("ze")||		
+		    buffer.substring( len- 2 ,len).equals("\u017ei")||  //-ži
+		    buffer.substring( len- 2 ,len).equals("\u017ee")){  //-že
+					
+		    buffer.replace(len- 2 ,len, "h");
+		    return;
+		}
+		if( buffer.substring( len- 3 ,len).equals("\u010dt\u011b")||  //-čtě
+		    buffer.substring( len- 3 ,len).equals("\u010dti")||       //-čti
+		    buffer.substring( len- 3 ,len).equals("\u010dt\u00ed")){  //-čtí
+						
+		    buffer.replace(len- 3 ,len, "ck");
+		    return;
+		}
+		if( buffer.substring( len- 2 ,len).equals("\u0161t\u011b")||  //-ště
+		    buffer.substring( len- 2 ,len).equals("\u0161ti")||       //-šti
+		    buffer.substring( len- 2 ,len).equals("\u0161t\u00ed")){  //-ští
+						
+		    buffer.replace(len- 2 ,len, "sk");
+		    return;
+		}
+		buffer.delete( len- 1 , len);
+		return;
+	}//palatalise
+	
+	private void removePossessives(StringBuffer buffer) {
+		int len=buffer.length();
+		
+		if( len> 5 ){
+			if( buffer.substring( len- 2 ,len).equals("ov")){
+				
+			    buffer.delete( len- 2 , len);
+			    return;
+			}
+			if( buffer.substring( len-2,len).equals("\u016fv")){ //-ův
+			 	
+	        	    buffer.delete( len- 2 , len);
+		            return;
+			}
+		        if( buffer.substring( len- 2 ,len).equals("in")){
+			 	
+			    buffer.delete( len- 1 , len);
+			    palatalise(buffer);
+			    return;
+			}
+		}
+		return;
+	}//removePossessives
+
+	private void removeCase(StringBuffer buffer) {
+		int len=buffer.length();
+		// 
+		if( (len> 7 )&&
+		    buffer.substring( len- 5 ,len).equals("atech")){
+			
+		    buffer.delete( len- 5 , len);
+		    return;
+		}//len>7
+		if( len> 6 ){
+		      if(buffer.substring( len- 4 ,len).equals("\u011btem")){   //-ětem
+		
+		         buffer.delete( len- 3 , len);
+		         palatalise(buffer);
+		         return;
+		      }
+		       if(buffer.substring( len- 4 ,len).equals("at\u016fm")){  //-atům
+		    	      buffer.delete( len- 4 , len);
+		    	      return;
+		      }
+		      
+		}
+		if( len> 5 ){
+			    if(buffer.substring( len-3,len).equals("ech")|| 
+				  buffer.substring( len-3,len).equals("ich")|| 
+				  buffer.substring( len-3,len).equals("\u00edch")){ //-ích
+				
+				  buffer.delete( len-2 , len);
+				  palatalise(buffer);
+				  return;
+				}
+		                if(buffer.substring( len-3,len).equals("\u00e9ho")|| //-ého
+				   buffer.substring( len-3,len).equals("\u011bmi")||  //-ěmi
+				   buffer.substring( len-3,len).equals("emi")||
+				   buffer.substring( len-3,len).equals("\u00e9mu")||  //-ému
+				   buffer.substring( len-3,len).equals("\u011bte")||  //-ěte
+				   buffer.substring( len-3,len).equals("\u011bti")||  //-ěti
+				   buffer.substring( len-3,len).equals("iho")||
+				   buffer.substring( len-3,len).equals("\u00edho")||  //-ího
+				   buffer.substring( len-3,len).equals("\u00edmi")||  //-ími
+				   buffer.substring( len-3,len).equals("imu")){
+				
+				   buffer.delete( len- 2 , len);
+				   palatalise(buffer);
+				   return;
+			        }
+		                if( buffer.substring( len-3,len).equals("\u00e1ch")|| //-ách
+				    buffer.substring( len-3,len).equals("ata")||
+				    buffer.substring( len-3,len).equals("aty")||
+				    buffer.substring( len-3,len).equals("\u00fdch")||   //-ých
+				    buffer.substring( len-3,len).equals("ama")||
+				    buffer.substring( len-3,len).equals("ami")||
+				    buffer.substring( len-3,len).equals("ov\u00e9")||   //-ové
+				    buffer.substring( len-3,len).equals("ovi")||
+				    buffer.substring( len-3,len).equals("\u00fdmi")){  //-ými
+				
+		                    buffer.delete( len- 3 , len);
+		                    return;
+				}
+		}  
+		if( len> 4){
+				if(buffer.substring( len-2,len).equals("em")){
+			
+			         buffer.delete( len- 1 , len);
+			         palatalise(buffer);
+			         return;
+			         
+			      }
+		                if( buffer.substring( len-2,len).equals("es")|| 
+				    buffer.substring( len-2,len).equals("\u00e9m")||    //-ém
+				    buffer.substring( len-2,len).equals("\u00edm")){   //-ím
+			
+			            buffer.delete( len- 2 , len);
+			            palatalise(buffer);
+			            return;
+			        }
+		                if( buffer.substring( len-2,len).equals("\u016fm")){  //-ům
+			
+			            buffer.delete( len- 2 , len);
+			            return;
+			        }
+		                if( buffer.substring( len-2,len).equals("at")|| 
+				    buffer.substring( len-2,len).equals("\u00e1m")||    //-ám
+				    buffer.substring( len-2,len).equals("os")||
+				    buffer.substring( len-2,len).equals("us")||   
+				    buffer.substring( len-2,len).equals("\u00fdm")||     //-ým
+				    buffer.substring( len-2,len).equals("mi")||   
+				    buffer.substring( len-2,len).equals("ou")){
+				
+				    buffer.delete( len- 2 , len);
+				    return;
+				}
+		}//len>4
+		if( len> 3){
+			 if( buffer.substring( len-1,len).equals("e")||
+			    buffer.substring( len-1,len).equals("i")){
+			
+			     palatalise(buffer);
+			     return;
+			}
+		            if( buffer.substring( len-1,len).equals("\u00ed")||  //-í
+				    buffer.substring( len-1,len).equals("\u011b")){      //-ě
+				
+				    palatalise(buffer);
+				    return;
+				}
+		            if( buffer.substring( len-1,len).equals("u")||
+				    buffer.substring( len-1,len).equals("y")||
+				    buffer.substring( len-1,len).equals("\u016f")){  //-ů
+					
+				    buffer.delete( len- 1 , len);
+				    return;
+				           
+				}
+		          if( buffer.substring( len-1,len).equals("a")||
+		        	  buffer.substring( len-1,len).equals("o")||
+				    buffer.substring( len-1,len).equals("\u00e1")||  // -á
+				    buffer.substring( len-1,len).equals("\u00e9")||  //-é
+				    buffer.substring( len-1,len).equals("\u00fd")){   //-ý
+				
+				    buffer.delete( len- 1 , len);
+				    return;
+				}
+		}//len>3
+	}
+	
+
+    private static void usage()
+    {
+        System.err.println("Usage: TestApp <algorithm> [<input file>] [-o <output file>]");
+    }
+
+    public static void main(String [] args) throws Throwable {
+        if (args.length < 1) {
+            usage();
+            return;
+        }
+
+        CzechStemmerLight stemmer = new CzechStemmerLight();
+
+	int arg = 1;
+
+	InputStream instream;
+	if (args.length > arg && !args[arg].equals("-o")) {
+	    instream = new FileInputStream(args[arg++]);
+	} else {
+	    instream = System.in;
+	}
+
+        OutputStream outstream;
+	if (args.length > arg) {
+            if (args.length != arg + 2 || !args[arg].equals("-o")) {
+                usage();
+                return;
+            }
+	    outstream = new FileOutputStream(args[arg + 1]);
+	} else {
+	    outstream = System.out;
+	}
+
+	Reader reader = new InputStreamReader(instream, StandardCharsets.UTF_8);
+	reader = new BufferedReader(reader);
+
+	Writer output = new OutputStreamWriter(outstream, StandardCharsets.UTF_8);
+	output = new BufferedWriter(output);
+
+	StringBuffer input = new StringBuffer();
+	int character;
+	while ((character = reader.read()) != -1) {
+	    char ch = (char) character;
+	    if (Character.isWhitespace(ch)) {
+		String result = stemmer.stem(input.toString());
+		output.write(result);
+		output.write('\n');
+		input.delete(0, input.length());
+	    } else {
+		input.append(ch < 127 ? Character.toLowerCase(ch) : ch);
+	    }
+	}
+	output.flush();
+    }
+	
+}//CzechStemmer_1

--- a/CzechStemmerLight.java
+++ b/CzechStemmerLight.java
@@ -77,11 +77,11 @@ public class CzechStemmerLight {
 		    buffer.replace(len- 3 ,len, "ck");
 		    return;
 		}
-		if( buffer.substring( len- 2 ,len).equals("\u0161t\u011b")||  //-ště
-		    buffer.substring( len- 2 ,len).equals("\u0161ti")||       //-šti
-		    buffer.substring( len- 2 ,len).equals("\u0161t\u00ed")){  //-ští
+		if( buffer.substring( len- 3 ,len).equals("\u0161t\u011b")||  //-ště
+		    buffer.substring( len- 3 ,len).equals("\u0161ti")||       //-šti
+		    buffer.substring( len- 3 ,len).equals("\u0161t\u00ed")){  //-ští
 						
-		    buffer.replace(len- 2 ,len, "sk");
+		    buffer.replace(len- 3 ,len, "sk");
 		    return;
 		}
 		buffer.delete( len- 1 , len);

--- a/algorithms/czech.sbl
+++ b/algorithms/czech.sbl
@@ -108,12 +108,12 @@ backwardmode (
         delete
         try palatalise_ecaron
       )
-      'e' 'ech' 'em' 'emi' 'es' 'ete' 'etem' // 'eti'
+      'e' 'ech' 'em' 'emi' 'ete' 'etem'
       (
         delete
         try palatalise_e
       )
-      'i' 'ich' 'iho' 'imu'
+      'i'
       (
         delete
         try palatalise_i

--- a/algorithms/czech.sbl
+++ b/algorithms/czech.sbl
@@ -1,5 +1,5 @@
 routines (
-  RV // R1
+  R1
   palatalise_e
   palatalise_ecaron
   palatalise_i
@@ -11,7 +11,7 @@ routines (
 
 externals ( stem )
 
-integers ( pV p1 x )
+integers ( p1 x )
 
 groupings ( v v_or_syllabic_c )
 
@@ -46,14 +46,8 @@ define v_or_syllabic_c v + 'lr'
 
 define mark_regions as (
 
-    $pV = limit
     $p1 = limit
     test(hop 3 setmark x)
-
-    do (
-        gopast non-v setmark pV
-        try($pV < x  $pV = x)  // at least 3
-    )
 
     do (
         // A syllabic consonant must occur between two consonants, or be
@@ -76,8 +70,7 @@ define mark_regions as (
 
 backwardmode (
 
-  define RV as $pV <= cursor
-  // define R1 as $p1 <= cursor
+  define R1 as $p1 <= cursor
 
   define palatalise_e as (
     [substring] among (
@@ -110,7 +103,7 @@ backwardmode (
   )
 
   define possessive_suffix as (
-    [substring] RV among (
+    [substring] R1 among (
       'ov' '{u*}v'
       (delete)
       'in'

--- a/algorithms/czech.sbl
+++ b/algorithms/czech.sbl
@@ -80,7 +80,7 @@ backwardmode (
   )
 
   define do_case as (
-    [substring] among (
+    [substring] R1 among (
       'atech'
       '{e^}tem' 'at{u*}m'
       '{a'}ch' '{y'}ch' 'ov{e'}' '{y'}mi'

--- a/algorithms/czech.sbl
+++ b/algorithms/czech.sbl
@@ -35,7 +35,14 @@ stringdef z^ '{U+017E}'
 
 define v 'aeiouy{a'}{e^}{e'}{i'}{o'}{u'}{u*}{y'}'
 
-define v_or_syllabic_c v + 'lr' //mn'
+// Some consonants in Czech can be syllabic - if these occur between two other
+// consonants then they act in a vowel-like way and it is helpful to include
+// them in the definition of R1.
+//
+// Some sources also list 'm' and 'n' as syllabic consonants for Czech but they
+// seem to be much rarer and including them makes no difference to the results
+// of stemming any words in our sample vocabulary list.
+define v_or_syllabic_c v + 'lr'
 
 define mark_regions as (
 
@@ -52,13 +59,15 @@ define mark_regions as (
         // A syllabic consonant must occur between two consonants, or be
         // preceded by a consonant and at the end of the word.
         //
-        // Instead of literally testing that, we check handle the first
-        // character specially, then we know that the character before is
-        // a consonant because otherwise we'd have stopped already.
+        // Instead of literally testing that, we handle the first character
+        // specially by only checking if it's a vowel; for subsequent
+        // characters we know that the character before is a consonant because
+        // otherwise we'd have stopped already.
         //
         // We also don't actually need to check the character after, since
         // if it's a vowel then that vowel means we'd end up at the same
-        // position after `gopast non-v` anyway.
+        // position after `gopast non-v` anyway, and if it's the end of the
+        // word then there's no non-v after it.
         (v or (next gopast v_or_syllabic_c)) gopast non-v
         setmark p1
         try($p1 < x  $p1 = x)  // at least 3

--- a/algorithms/czech.sbl
+++ b/algorithms/czech.sbl
@@ -1,9 +1,8 @@
 routines (
   R1
   palatalise_e
-  palatalise_ecaron
+  palatalise_ecaron_or_iacute
   palatalise_i
-  palatalise_iacute
   mark_regions
   possessive_suffix
   case_suffix
@@ -79,7 +78,7 @@ backwardmode (
     )
   )
 
-  define palatalise_ecaron as (
+  define palatalise_ecaron_or_iacute as (
     [substring] among (
       '{c^}t' (<- 'ck')
       '{s^}t' (<- 'sk')
@@ -90,13 +89,6 @@ backwardmode (
     [substring] among (
       'c' '{c^}' (<- 'k')
       'z' '{z^}' (<- 'h')
-      '{c^}t' (<- 'ck')
-      '{s^}t' (<- 'sk')
-    )
-  )
-
-  define palatalise_iacute as (
-    [substring] among (
       '{c^}t' (<- 'ck')
       '{s^}t' (<- 'sk')
     )
@@ -127,7 +119,7 @@ backwardmode (
       '{e^}' '{e^}tem' '{e^}mi' '{e^}te' '{e^}ti'
       (
         delete
-        try palatalise_ecaron
+        try palatalise_ecaron_or_iacute
       )
       'e' 'ech' 'em' 'emi' 'ete' 'etem'
       (
@@ -142,7 +134,7 @@ backwardmode (
       '{i'}' '{i'}ch' '{i'}ho' '{i'}m' '{i'}mi' '{i'}mu'
       (
         delete
-        try palatalise_iacute
+        try palatalise_ecaron_or_iacute
       )
     )
   )

--- a/algorithms/czech.sbl
+++ b/algorithms/czech.sbl
@@ -237,7 +237,7 @@ define stem as (
     do_possessive
     // light and aggressive are the same to this point
     // comment next line for light stemmer
-    do_aggressive
+    // do_aggressive
   )
 )
 

--- a/algorithms/czech.sbl
+++ b/algorithms/czech.sbl
@@ -79,7 +79,7 @@ backwardmode (
       '{e^}tem' 'at{u*}m'
       '{a'}ch' '{y'}ch' 'ov{e'}' '{y'}mi'
       'ata' 'aty' 'ama' 'ami' 'ovi'
-      'at' '{a'}m' 'os' 'us' '{y'}m' 'mi' 'ou'
+      'at' '{a'}m' 'os' 'us' '{u*}m' '{y'}m' 'mi' 'ou'
       'u' 'y' '{u*}' 'a' 'o' '{a'}' '{e'}' '{y'}'
       (delete)
       'ech' 'ich' '{i'}ch'

--- a/algorithms/czech.sbl
+++ b/algorithms/czech.sbl
@@ -13,7 +13,7 @@ externals ( stem )
 
 integers ( pV p1 x )
 
-groupings ( v syllabic_c )
+groupings ( v v_or_syllabic_c )
 
 stringescapes {}
 
@@ -35,7 +35,7 @@ stringdef z^ '{U+017E}'
 
 define v 'aeiouy{a'}{e^}{e'}{i'}{o'}{u'}{u*}{y'}'
 
-define syllabic_c 'lr' //mn'
+define v_or_syllabic_c v + 'lr' //mn'
 
 define mark_regions as (
 
@@ -52,10 +52,14 @@ define mark_regions as (
         // A syllabic consonant must occur between two consonants, or be
         // preceded by a consonant and at the end of the word.
         //
-        // However, we don't actually need to check the character after, since
+        // Instead of literally testing that, we check handle the first
+        // character specially, then we know that the character before is
+        // a consonant because otherwise we'd have stopped already.
+        //
+        // We also don't actually need to check the character after, since
         // if it's a vowel then that vowel means we'd end up at the same
         // position after `gopast non-v` anyway.
-        gopast ( v or (non-v syllabic_c) ) gopast non-v
+        (v or (next gopast v_or_syllabic_c)) gopast non-v
         setmark p1
         try($p1 < x  $p1 = x)  // at least 3
     )

--- a/algorithms/czech.sbl
+++ b/algorithms/czech.sbl
@@ -50,7 +50,7 @@ backwardmode (
 
   define palatalise as (
     [substring] RV among (
-      'ci' 'ce' '{c^}i' '{c^}'
+      'ci' 'ce' '{c^}i' '{c^}e'
       (<- 'k')
       'zi' 'ze' '{z^}i' '{z^}e'
       (<- 'h')

--- a/algorithms/czech.sbl
+++ b/algorithms/czech.sbl
@@ -2,8 +2,8 @@ routines (
   RV R1
   palatalise
   mark_regions
-  do_possessive
-  do_case
+  possessive_suffix
+  case_suffix
 )
 
 externals ( stem )
@@ -61,7 +61,7 @@ backwardmode (
     )
   )
 
-  define do_possessive as (
+  define possessive_suffix as (
     [substring] RV among (
       'ov' '{u*}v'
       (delete)
@@ -73,7 +73,7 @@ backwardmode (
     )
   )
 
-  define do_case as (
+  define case_suffix as (
     [substring] R1 among (
       'atech'
       '{e^}tem' 'at{u*}m'
@@ -103,8 +103,8 @@ backwardmode (
 define stem as (
   do mark_regions
   backwards (
-    do_case
-    do_possessive
+    do case_suffix
+    do possessive_suffix
   )
 )
 

--- a/algorithms/czech.sbl
+++ b/algorithms/czech.sbl
@@ -54,9 +54,9 @@ backwardmode (
       (<- 'k')
       'zi' 'ze' '{z^}i' '{z^}e'
       (<- 'h')
-      '{c^}t{e^}' '{c^}ti' '{c^}t{e'}'
+      '{c^}t{e^}' '{c^}ti' '{c^}t{i'}'
       (<- 'ck')
-      '{s^}t{e^}' '{s^}ti' '{s^}t{e'}'
+      '{s^}t{e^}' '{s^}ti' '{s^}t{i'}'
       (<- 'sk')
     )
   )

--- a/algorithms/czech.sbl
+++ b/algorithms/czech.sbl
@@ -11,9 +11,9 @@ routines (
 
 externals ( stem )
 
-integers ( pV p1 )
+integers ( pV p1 x )
 
-groupings ( v )
+groupings ( v syllabic_c )
 
 stringescapes {}
 
@@ -35,14 +35,29 @@ stringdef z^ '{U+017E}'
 
 define v 'aeiouy{a'}{e^}{e'}{i'}{o'}{u'}{u*}{y'}'
 
+define syllabic_c 'lr' //mn'
+
 define mark_regions as (
 
     $pV = limit
     $p1 = limit
+    test(hop 3 setmark x)
 
     do (
         gopast non-v setmark pV
-        gopast non-v gopast v setmark p1
+        try($pV < x  $pV = x)  // at least 3
+    )
+
+    do (
+        // A syllabic consonant must occur between two consonants, or be
+        // preceded by a consonant and at the end of the word.
+        //
+        // However, we don't actually need to check the character after, since
+        // if it's a vowel then that vowel means we'd end up at the same
+        // position after `gopast non-v` anyway.
+        gopast ( v or (non-v syllabic_c) ) gopast non-v
+        setmark p1
+        try($p1 < x  $p1 = x)  // at least 3
     )
 )
 

--- a/algorithms/czech.sbl
+++ b/algorithms/czech.sbl
@@ -1,5 +1,5 @@
 routines (
-  RV R1
+  RV // R1
   palatalise_e
   palatalise_ecaron
   palatalise_i
@@ -49,7 +49,7 @@ define mark_regions as (
 backwardmode (
 
   define RV as $pV <= cursor
-  define R1 as $p1 <= cursor
+  // define R1 as $p1 <= cursor
 
   define palatalise_e as (
     [substring] among (

--- a/algorithms/czech.sbl
+++ b/algorithms/czech.sbl
@@ -118,7 +118,7 @@ backwardmode (
         delete
         try palatalise_i
       )
-      '{i'}' '{i'}ch' '{i'}ho' '{i'}m' '{i'}mi'
+      '{i'}' '{i'}ch' '{i'}ho' '{i'}m' '{i'}mi' '{i'}mu'
       (
         delete
         try palatalise_iacute

--- a/algorithms/czech.sbl
+++ b/algorithms/czech.sbl
@@ -244,5 +244,6 @@ define stem as (
 // Ljiljana Dolamic and Jacques Savoy. 2009.
 // Indexing and stemming approaches for the Czech language.
 // Inf. Process. Manage. 45, 6 (November 2009), 714-720.
+// based on Java code by Ljiljana Dolamic:
 // http://members.unine.ch/jacques.savoy/clef/CzechStemmerLight.txt
 // http://members.unine.ch/jacques.savoy/clef/CzechStemmerAgressive.txt

--- a/algorithms/czech.sbl
+++ b/algorithms/czech.sbl
@@ -1,6 +1,9 @@
 routines (
   RV R1
-  palatalise
+  palatalise_e
+  palatalise_ecaron
+  palatalise_i
+  palatalise_iacute
   mark_regions
   possessive_suffix
   case_suffix
@@ -48,16 +51,33 @@ backwardmode (
   define RV as $pV <= cursor
   define R1 as $p1 <= cursor
 
-  define palatalise as (
-    [substring] RV among (
-      'ci' 'ce' '{c^}i' '{c^}e'
-      (<- 'k')
-      'zi' 'ze' '{z^}i' '{z^}e'
-      (<- 'h')
-      '{c^}t{e^}' '{c^}ti' '{c^}t{i'}'
-      (<- 'ck')
-      '{s^}t{e^}' '{s^}ti' '{s^}t{i'}'
-      (<- 'sk')
+  define palatalise_e as (
+    [substring] among (
+      'c' '{c^}' (<- 'k')
+      'z' '{z^}' (<- 'h')
+    )
+  )
+
+  define palatalise_ecaron as (
+    [substring] among (
+      '{c^}t' (<- 'ck')
+      '{s^}t' (<- 'sk')
+    )
+  )
+
+  define palatalise_i as (
+    [substring] among (
+      'c' '{c^}' (<- 'k')
+      'z' '{z^}' (<- 'h')
+      '{c^}t' (<- 'ck')
+      '{s^}t' (<- 'sk')
+    )
+  )
+
+  define palatalise_iacute as (
+    [substring] among (
+      '{c^}t' (<- 'ck')
+      '{s^}t' (<- 'sk')
     )
   )
 
@@ -68,33 +88,40 @@ backwardmode (
       'in'
       (
         delete
-        try palatalise
+        try palatalise_i
       )
     )
   )
 
   define case_suffix as (
-    [substring] R1 among (
+    setlimit tomark p1 for ( [substring] ) among (
       'atech'
-      '{e^}tem' 'at{u*}m'
+      'at{u*}m'
       '{a'}ch' '{y'}ch' 'ov{e'}' '{y'}mi'
       'ata' 'aty' 'ama' 'ami' 'ovi'
       'at' '{a'}m' 'os' 'us' '{u*}m' '{y'}m' 'mi' 'ou'
+      '{e'}ho' '{e'}m' '{e'}mu'
       'u' 'y' '{u*}' 'a' 'o' '{a'}' '{e'}' '{y'}'
       (delete)
-      'ech' 'ich' '{i'}ch'
-      '{e'}ho' '{e^}mi' '{e'}mu' '{e^}te' '{e^}ti' '{i'}ho' '{i'}mi'
-      'emi' 'iho' 'imu'
-      '{e'}m' '{i'}m' 'es'
-      'e' 'i' '{i'}' '{e^}'
+      '{e^}' '{e^}tem' '{e^}mi' '{e^}te' '{e^}ti'
       (
         delete
-        try palatalise
+        try palatalise_ecaron
       )
-      'em'
+      'e' 'ech' 'em' 'emi' 'es' 'ete' 'etem' // 'eti'
       (
-        <- 'e'
-        try palatalise
+        delete
+        try palatalise_e
+      )
+      'i' 'ich' 'iho' 'imu'
+      (
+        delete
+        try palatalise_i
+      )
+      '{i'}' '{i'}ch' '{i'}ho' '{i'}m' '{i'}mi'
+      (
+        delete
+        try palatalise_iacute
       )
     )
   )

--- a/algorithms/czech.sbl
+++ b/algorithms/czech.sbl
@@ -1,0 +1,248 @@
+routines (
+  RV R1
+  palatalise
+  mark_regions
+  do_possessive
+  do_case
+  do_comparative
+  do_diminutive
+  do_augmentative
+  do_derivational
+  do_deriv_single
+  do_aggressive
+)
+
+externals ( stem )
+
+integers ( pV p1 )
+
+groupings ( v )
+
+stringescapes {}
+
+stringdef a' '{U+00E1}'
+stringdef c^ '{U+010D}'
+stringdef d^ '{U+010F}'
+stringdef e' '{U+00E9}'
+stringdef e^ '{U+011B}'
+stringdef i' '{U+00ED}'
+stringdef n^ '{U+0148}'
+stringdef o' '{U+00F3}'
+stringdef r^ '{U+0159}'
+stringdef s^ '{U+0161}'
+stringdef t^ '{U+0165}'
+stringdef u' '{U+00FA}'
+stringdef u* '{U+016F}'
+stringdef y' '{U+00FD}'
+stringdef z^ '{U+017E}'
+
+define v 'aeiouy{a'}{e^}{e'}{i'}{o'}{u'}{u*}{y'}'
+
+define mark_regions as (
+
+    $pV = limit
+    $p1 = limit
+
+    do (
+        gopast non-v setmark pV
+        gopast non-v gopast v setmark p1
+    )
+)
+
+backwardmode (
+
+  define RV as $pV <= cursor
+  define R1 as $p1 <= cursor
+
+  define palatalise as (
+    [substring] RV among (
+      'ci' 'ce' '{c^}i' '{c^}'
+      (<- 'k')
+      'zi' 'ze' '{z^}i' '{z^}e'
+      (<- 'h')
+      '{c^}t{e^}' '{c^}ti' '{c^}t{e'}'
+      (<- 'ck')
+      '{s^}t{e^}' '{s^}ti' '{s^}t{e'}'
+      (<- 'sk')
+    )
+  )
+
+  define do_possessive as (
+    [substring] RV among (
+      'ov' '{u*}v'
+      (delete)
+      'in'
+      (
+        delete
+        try palatalise
+      )
+    )
+  )
+
+  define do_case as (
+    [substring] among (
+      'atech'
+      '{e^}tem' 'at{u*}m'
+      '{a'}ch' '{y'}ch' 'ov{e'}' '{y'}mi'
+      'ata' 'aty' 'ama' 'ami' 'ovi'
+      'at' '{a'}m' 'os' 'us' '{y'}m' 'mi' 'ou'
+      'u' 'y' '{u*}' 'a' 'o' '{a'}' '{e'}' '{y'}'
+      (delete)
+      'ech' 'ich' '{i'}ch'
+      '{e'}ho' '{e^}mi' '{e'}mu' '{e^}te' '{e^}ti' '{i'}ho' '{i'}mi'
+      'emi' 'iho' 'imu'
+      '{e'}m' '{i'}m' 'es'
+      'e' 'i' '{i'}' '{e^}'
+      (
+        delete
+        try palatalise
+      )
+      'em'
+      (
+        <- 'e'
+        try palatalise
+      )
+    )
+  )
+
+  define do_derivational as (
+    [substring] R1 among (
+      'obinec'
+      'ovisk' 'ovstv' 'ovi{s^}t' 'ovn{i'}k'
+      '{a'}sek' 'loun' 'nost' 'teln' 'ovec' 'ov{i'}k' 'ovtv' 'ovin' '{s^}tin'
+      '{a'}rn' 'och' 'ost' 'ovn' 'oun' 'out' 'ou{s^}' 'u{s^}k'
+      'kyn' '{c^}an' 'k{a'}{r^}' 'n{e'}{r^}' 'n{i'}k' 'ctv' 'stv'
+      '{a'}{c^}' 'a{c^}' '{a'}n' 'an' '{a'}{r^}' 'as'
+      'ob' 'ot' 'ov' 'o{n^}' 'ul' 'yn'
+      '{c^}k' '{c^}n' 'dl' 'nk' 'tv' 'tk' 'vk'
+      (delete)
+      'ion{a'}{r^}'
+      'inec' 'itel'
+      'i{a'}n' 'ist' 'isk' 'i{s^}k' 'itb'
+      'ic' 'in' 'it' 'iv'
+      (
+        <- 'i'
+        palatalise
+      )
+      'enic' 'ec' 'en'
+      (
+        <- 'e'
+        palatalise
+      )
+      '{e'}{r^}'
+      (
+        <- '{e'}'
+        palatalise
+      )
+      '{e^}n'
+      (
+        <- '{e^}'
+        palatalise
+      )
+      '{i'}rn'
+      '{i'}{r^}' '{i'}n'
+      (
+        <- '{i'}'
+        palatalise
+      )
+    )
+  )
+  define do_deriv_single as (
+    [substring] among (
+      'c' '{c^}' 'k' 'l' 'n' 't'
+      (delete)
+    )
+  )
+
+
+  define do_augmentative as (
+    [substring] among (
+      'ajzn' '{a'}k'
+      (delete)
+      'izn' 'isk'
+      (
+        <- 'i'
+        palatalise
+      )
+    )
+  )
+
+  define do_diminutive as (
+    [substring] among (
+      'ou{s^}ek' '{a'}{c^}ek' 'a{c^}ek' 'o{c^}ek' 'u{c^}ek'
+      'anek' 'onek' 'unek' '{a'}nek'
+      'e{c^}k' '{e'}{c^}k' 'i{c^}k' '{i'}{c^}k' 'enk' '{e'}nk' 'ink' '{i'}nk'
+      '{a'}{c^}k' 'a{c^}k' 'o{c^}k' 'u{c^}k' 'ank' 'onk' 'unk'
+      '{a'}tk' '{a'}nk' 'u{s^}k'
+      'k'
+      (delete)
+      'e{c^}ek' 'enek' 'ek'
+      (
+        <- 'e'
+        palatalise
+      )
+      '{e'}{c^}ek' '{e'}k'
+      (
+        <- '{e'}'
+        palatalise
+      )
+      'i{c^}ek' 'inek' 'ik'
+      (
+        <- 'i'
+        palatalise
+      )
+      '{i'}{c^}ek' '{i'}k'
+      (
+        <- '{i'}'
+        palatalise
+      )
+      '{a'}k'
+       (<- '{a'}')
+      'ak'
+       (<- 'a')
+      'ok'
+       (<- 'o')
+      'uk'
+       (<- 'u')
+    )
+  )
+
+  define do_comparative as (
+    [substring] among (
+      '{e^}j{s^}'
+      (
+        <- '{e^}'
+        palatalise
+      )
+      'ej{s^}'
+      (
+        <- 'e'
+        palatalise
+      )
+    )
+  )
+
+  define do_aggressive as (
+    do do_comparative
+    do do_diminutive
+    do do_augmentative
+    do_derivational or do_deriv_single
+  )
+)
+
+define stem as (
+  do mark_regions
+  backwards (
+    do_case
+    do_possessive
+    // light and aggressive are the same to this point
+    // comment next line for light stemmer
+    do_aggressive
+  )
+)
+
+// Ljiljana Dolamic and Jacques Savoy. 2009.
+// Indexing and stemming approaches for the Czech language.
+// Inf. Process. Manage. 45, 6 (November 2009), 714-720.
+// http://members.unine.ch/jacques.savoy/clef/CzechStemmerLight.txt
+// http://members.unine.ch/jacques.savoy/clef/CzechStemmerAgressive.txt

--- a/algorithms/czech.sbl
+++ b/algorithms/czech.sbl
@@ -4,12 +4,6 @@ routines (
   mark_regions
   do_possessive
   do_case
-  do_comparative
-  do_diminutive
-  do_augmentative
-  do_derivational
-  do_deriv_single
-  do_aggressive
 )
 
 externals ( stem )
@@ -104,130 +98,6 @@ backwardmode (
       )
     )
   )
-
-  define do_derivational as (
-    [substring] R1 among (
-      'obinec'
-      'ovisk' 'ovstv' 'ovi{s^}t' 'ovn{i'}k'
-      '{a'}sek' 'loun' 'nost' 'teln' 'ovec' 'ov{i'}k' 'ovtv' 'ovin' '{s^}tin'
-      '{a'}rn' 'och' 'ost' 'ovn' 'oun' 'out' 'ou{s^}' 'u{s^}k'
-      'kyn' '{c^}an' 'k{a'}{r^}' 'n{e'}{r^}' 'n{i'}k' 'ctv' 'stv'
-      '{a'}{c^}' 'a{c^}' '{a'}n' 'an' '{a'}{r^}' 'as'
-      'ob' 'ot' 'ov' 'o{n^}' 'ul' 'yn'
-      '{c^}k' '{c^}n' 'dl' 'nk' 'tv' 'tk' 'vk'
-      (delete)
-      'ion{a'}{r^}'
-      'inec' 'itel'
-      'i{a'}n' 'ist' 'isk' 'i{s^}k' 'itb'
-      'ic' 'in' 'it' 'iv'
-      (
-        <- 'i'
-        palatalise
-      )
-      'enic' 'ec' 'en'
-      (
-        <- 'e'
-        palatalise
-      )
-      '{e'}{r^}'
-      (
-        <- '{e'}'
-        palatalise
-      )
-      '{e^}n'
-      (
-        <- '{e^}'
-        palatalise
-      )
-      '{i'}rn'
-      '{i'}{r^}' '{i'}n'
-      (
-        <- '{i'}'
-        palatalise
-      )
-    )
-  )
-  define do_deriv_single as (
-    [substring] among (
-      'c' '{c^}' 'k' 'l' 'n' 't'
-      (delete)
-    )
-  )
-
-
-  define do_augmentative as (
-    [substring] among (
-      'ajzn' '{a'}k'
-      (delete)
-      'izn' 'isk'
-      (
-        <- 'i'
-        palatalise
-      )
-    )
-  )
-
-  define do_diminutive as (
-    [substring] among (
-      'ou{s^}ek' '{a'}{c^}ek' 'a{c^}ek' 'o{c^}ek' 'u{c^}ek'
-      'anek' 'onek' 'unek' '{a'}nek'
-      'e{c^}k' '{e'}{c^}k' 'i{c^}k' '{i'}{c^}k' 'enk' '{e'}nk' 'ink' '{i'}nk'
-      '{a'}{c^}k' 'a{c^}k' 'o{c^}k' 'u{c^}k' 'ank' 'onk' 'unk'
-      '{a'}tk' '{a'}nk' 'u{s^}k'
-      'k'
-      (delete)
-      'e{c^}ek' 'enek' 'ek'
-      (
-        <- 'e'
-        palatalise
-      )
-      '{e'}{c^}ek' '{e'}k'
-      (
-        <- '{e'}'
-        palatalise
-      )
-      'i{c^}ek' 'inek' 'ik'
-      (
-        <- 'i'
-        palatalise
-      )
-      '{i'}{c^}ek' '{i'}k'
-      (
-        <- '{i'}'
-        palatalise
-      )
-      '{a'}k'
-       (<- '{a'}')
-      'ak'
-       (<- 'a')
-      'ok'
-       (<- 'o')
-      'uk'
-       (<- 'u')
-    )
-  )
-
-  define do_comparative as (
-    [substring] among (
-      '{e^}j{s^}'
-      (
-        <- '{e^}'
-        palatalise
-      )
-      'ej{s^}'
-      (
-        <- 'e'
-        palatalise
-      )
-    )
-  )
-
-  define do_aggressive as (
-    do do_comparative
-    do do_diminutive
-    do do_augmentative
-    do_derivational or do_deriv_single
-  )
 )
 
 define stem as (
@@ -235,9 +105,6 @@ define stem as (
   backwards (
     do_case
     do_possessive
-    // light and aggressive are the same to this point
-    // comment next line for light stemmer
-    // do_aggressive
   )
 )
 
@@ -246,4 +113,3 @@ define stem as (
 // Inf. Process. Manage. 45, 6 (November 2009), 714-720.
 // based on Java code by Ljiljana Dolamic:
 // http://members.unine.ch/jacques.savoy/clef/CzechStemmerLight.txt
-// http://members.unine.ch/jacques.savoy/clef/CzechStemmerAgressive.txt

--- a/algorithms/czech.sbl
+++ b/algorithms/czech.sbl
@@ -99,7 +99,7 @@ backwardmode (
       'at{u*}m'
       '{a'}ch' '{y'}ch' 'ov{e'}' '{y'}mi'
       'ata' 'aty' 'ama' 'ami' 'ovi'
-      'at' '{a'}m' 'os' 'us' '{u*}m' '{y'}m' 'mi' 'ou'
+      'at' '{a'}m' 'us' '{u*}m' '{y'}m' 'mi' 'ou'
       '{e'}ho' '{e'}m' '{e'}mu'
       'u' 'y' '{u*}' 'a' 'o' '{a'}' '{e'}' '{y'}'
       (delete)

--- a/algorithms/czech.sbl
+++ b/algorithms/czech.sbl
@@ -1,7 +1,6 @@
 routines (
   R1
   palatalise_e
-  palatalise_ecaron
   palatalise_i
   mark_regions
   possessive_suffix
@@ -80,19 +79,21 @@ backwardmode (
     )
   )
 
-  define palatalise_ecaron as (
-    [substring] among (
-      '{cv}t' (<- 'ck')
-      '{sv}t' (<- 'sk')
-    )
-  )
-
   define palatalise_i as (
     [substring] among (
       'c' '{cv}' (<- 'k')
       'z' '{zv}' (<- 'h')
       '{cv}t' (<- 'ck')
-      '{sv}t' (<- 'sk')
+      // -št -> -sk
+      '{sv}t' // e.g. čeština
+        (<-'sk')
+      '{a'}{sv}t' // e.g. plášti
+      'de{sv}t' // e.g. dešti
+      'i{sv}t' // e.g. bojišti
+      '{i'}{sv}t' // e.g. příští
+      'le{sv}t' // e.g. kleští
+      'pou{sv}t' // e.g. poušti, spouští
+        ()
     )
   )
 
@@ -122,7 +123,6 @@ backwardmode (
       '{ev}m' // e.g. koněm
       (
         delete
-        try palatalise_ecaron
       )
       'e' 'ech' 'em' 'emi' 'ete' 'etem'
       (
@@ -139,8 +139,7 @@ backwardmode (
       )
       '{tv}' '{tv}mi'
       ( // Conflate e.g. oběť and oběťmi with obětech; hradišť with hradišti.
-        delete attach 't'
-        try palatalise_ecaron
+        <-'t'
       )
       'i'
       '{i'}' '{i'}ch' '{i'}ho' '{i'}m' '{i'}mi' '{i'}mu'

--- a/algorithms/czech.sbl
+++ b/algorithms/czech.sbl
@@ -83,14 +83,14 @@ backwardmode (
   define palatalise_e as (
     [substring] among (
       'c' (<- 'k')
-      'z' '{zv}' (<- 'h')
+      'z' (<- 'h')
     )
   )
 
   define palatalise_i as (
     [substring] among (
       'c' (<- 'k')
-      'z' '{zv}' (<- 'h')
+      'z' (<- 'h')
       '{cv}t' (<- 'ck')
       // -št -> -sk
       '{sv}t' // e.g. čeština

--- a/algorithms/czech.sbl
+++ b/algorithms/czech.sbl
@@ -40,7 +40,9 @@ define v 'aeiouy{a'}{e^}{e'}{i'}{o'}{u'}{u*}{y'}'
 //
 // Some sources also list 'm' and 'n' as syllabic consonants for Czech but they
 // seem to be much rarer and including them makes no difference to the results
-// of stemming any words in our sample vocabulary list.
+// of stemming any words in our sample vocabulary list.  Checking on a larger
+// vocabulary list (also from wikipedia but with a lower cut-off frequency)
+// all but one of the affected words don't seem to actually be Czech words.
 define v_or_syllabic_c v + 'lr'
 
 define mark_regions as (

--- a/algorithms/czech.sbl
+++ b/algorithms/czech.sbl
@@ -129,6 +129,11 @@ backwardmode (
         delete
         try palatalise_e
       )
+      '{tv}' '{tv}mi'
+      ( // Conflate e.g. oběť and oběťmi with obětech; hradišť with hradišti.
+        delete attach 't'
+        try palatalise_ecaron
+      )
       'i'
       '{i'}' '{i'}ch' '{i'}ho' '{i'}m' '{i'}mi' '{i'}mu'
       (

--- a/algorithms/czech.sbl
+++ b/algorithms/czech.sbl
@@ -129,6 +129,14 @@ backwardmode (
         delete
         try palatalise_e
       )
+      'ec'
+      ( // Conflate e.g. obec with obce, obcemi, obci, obcí, obcích
+        // The correct linguistic root is the -ec forms, but we map to -c as it
+        // seems much harder to reliably map the various -c- forms to -ec.
+        test non-v
+        delete attach 'c'
+        try palatalise_e
+      )
       '{tv}' '{tv}mi'
       ( // Conflate e.g. oběť and oběťmi with obětech; hradišť with hradišti.
         delete attach 't'

--- a/algorithms/czech.sbl
+++ b/algorithms/czech.sbl
@@ -157,6 +157,19 @@ backwardmode (
         )
         <-'k'
       )
+      'et'
+      ( // Conflate e.g. počet with počte, počtu, počty, etc.
+        // The correct linguistic root is the -et form, but we map to -t as
+        // that's easier to do reliably than to map the other way.
+        among (
+          'uc' // e.g. tucet but not dvacet.
+          '{cv}'
+          'h'
+          'ok' // e.g. loket but not paket.
+          'kar' // e.g. karet but not cigaret.
+        )
+        <-'t'
+      )
       '{tv}' '{tv}mi'
       ( // Conflate e.g. oběť and oběťmi with obětech; hradišť with hradišti.
         <-'t'

--- a/algorithms/czech.sbl
+++ b/algorithms/czech.sbl
@@ -83,14 +83,12 @@ backwardmode (
   define palatalise_e as (
     [substring] among (
       'c' (<- 'k')
-      'z' (<- 'h')
     )
   )
 
   define palatalise_i as (
     [substring] among (
       'c' (<- 'k')
-      'z' (<- 'h')
       '{cv}t' (<- 'ck')
       // -št -> -sk
       '{sv}t' // e.g. čeština

--- a/algorithms/czech.sbl
+++ b/algorithms/czech.sbl
@@ -129,18 +129,26 @@ backwardmode (
         delete
         try palatalise_e
       )
+      'eb'
+      ( // Conflate e.g. skladeb with skladba, skladbě, skladby, etc.
+        // The correct linguistic root is the -eb form, but we map to -b as
+        // that's easier to do reliably than to map the other way.
+        test non-v
+        not 't{rv}' // potřeb
+        <-'b'
+      )
       'ec'
       ( // Conflate e.g. obec with obce, obcemi, obci, obcí, obcích.
-        // The correct linguistic root is the -ec forms, but we map to -c as it
-        // seems much harder to reliably map the various -c- forms to -ec.
+        // The correct linguistic root is the -ec form, but we map to -c as
+        // that's easier to do reliably than to map the other way.
         test non-v
         delete attach 'c'
         try palatalise_e
       )
       'ek'
       ( // Conflate e.g. článek with článkem, článku, článků, článkům, články.
-        // The correct linguistic root is the -ek forms, but we map to -k as it
-        // seems much harder to reliably map the various -k- forms to -ek.
+        // The correct linguistic root is the -ek form, but we map to -k as
+        // that's easier to do reliably than to map the other way.
         test non-v
         not among (
           'dot' // dotek

--- a/algorithms/czech.sbl
+++ b/algorithms/czech.sbl
@@ -119,6 +119,7 @@ backwardmode (
       'u' 'y' '{u*}' 'a' 'o' '{a'}' '{e'}' '{y'}'
       (delete)
       '{e^}' '{e^}tem' '{e^}mi' '{e^}te' '{e^}ti'
+      '{e^}m' // e.g. koněm
       (
         delete
         try palatalise_ecaron_or_iacute

--- a/algorithms/czech.sbl
+++ b/algorithms/czech.sbl
@@ -16,23 +16,23 @@ groupings ( v v_or_syllabic_c )
 
 stringescapes {}
 
-stringdef a' '{U+00E1}'
-stringdef c^ '{U+010D}'
-stringdef d^ '{U+010F}'
-stringdef e' '{U+00E9}'
-stringdef e^ '{U+011B}'
-stringdef i' '{U+00ED}'
-stringdef n^ '{U+0148}'
-stringdef o' '{U+00F3}'
-stringdef r^ '{U+0159}'
-stringdef s^ '{U+0161}'
-stringdef t^ '{U+0165}'
-stringdef u' '{U+00FA}'
-stringdef u* '{U+016F}'
-stringdef y' '{U+00FD}'
-stringdef z^ '{U+017E}'
+stringdef a' '{U+00E1}' // á
+stringdef cv '{U+010D}' // č
+stringdef dv '{U+010F}' // ď
+stringdef e' '{U+00E9}' // é
+stringdef ev '{U+011B}' // ě
+stringdef i' '{U+00ED}' // í
+stringdef nv '{U+0148}' // ň
+stringdef o' '{U+00F3}' // ó
+stringdef rv '{U+0159}' // ř
+stringdef sv '{U+0161}' // š
+stringdef tv '{U+0165}' // ť
+stringdef u' '{U+00FA}' // ú
+stringdef uo '{U+016F}' // ů
+stringdef y' '{U+00FD}' // ý
+stringdef zv '{U+017E}' // ž
 
-define v 'aeiouy{a'}{e^}{e'}{i'}{o'}{u'}{u*}{y'}'
+define v 'aeiouy{a'}{ev}{e'}{i'}{o'}{u'}{uo}{y'}'
 
 // Some consonants in Czech can be syllabic - if these occur between two other
 // consonants then they act in a vowel-like way and it is helpful to include
@@ -75,30 +75,30 @@ backwardmode (
 
   define palatalise_e as (
     [substring] among (
-      'c' '{c^}' (<- 'k')
-      'z' '{z^}' (<- 'h')
+      'c' '{cv}' (<- 'k')
+      'z' '{zv}' (<- 'h')
     )
   )
 
   define palatalise_ecaron as (
     [substring] among (
-      '{c^}t' (<- 'ck')
-      '{s^}t' (<- 'sk')
+      '{cv}t' (<- 'ck')
+      '{sv}t' (<- 'sk')
     )
   )
 
   define palatalise_i as (
     [substring] among (
-      'c' '{c^}' (<- 'k')
-      'z' '{z^}' (<- 'h')
-      '{c^}t' (<- 'ck')
-      '{s^}t' (<- 'sk')
+      'c' '{cv}' (<- 'k')
+      'z' '{zv}' (<- 'h')
+      '{cv}t' (<- 'ck')
+      '{sv}t' (<- 'sk')
     )
   )
 
   define possessive_suffix as (
     [substring] R1 among (
-      'ov' '{u*}v'
+      'ov' '{uo}v'
       (delete)
       'in'
       (
@@ -111,15 +111,15 @@ backwardmode (
   define case_suffix as (
     setlimit tomark p1 for ( [substring] ) among (
       'atech'
-      'at{u*}m'
+      'at{uo}m'
       '{a'}ch' '{y'}ch' 'ov{e'}' '{y'}mi'
       'ata' 'aty' 'ama' 'ami' 'ovi'
-      'at' '{a'}m' 'us' '{u*}m' '{y'}m' 'mi' 'ou'
+      'at' '{a'}m' 'us' '{uo}m' '{y'}m' 'mi' 'ou'
       '{e'}ho' '{e'}m' '{e'}mu'
-      'u' 'y' '{u*}' 'a' 'o' '{a'}' '{e'}' '{y'}'
+      'u' 'y' '{uo}' 'a' 'o' '{a'}' '{e'}' '{y'}'
       (delete)
-      '{e^}' '{e^}tem' '{e^}mi' '{e^}te' '{e^}ti'
-      '{e^}m' // e.g. koněm
+      '{ev}' '{ev}tem' '{ev}mi' '{ev}te' '{ev}ti'
+      '{ev}m' // e.g. koněm
       (
         delete
         try palatalise_ecaron

--- a/algorithms/czech.sbl
+++ b/algorithms/czech.sbl
@@ -130,12 +130,24 @@ backwardmode (
         try palatalise_e
       )
       'ec'
-      ( // Conflate e.g. obec with obce, obcemi, obci, obcí, obcích
+      ( // Conflate e.g. obec with obce, obcemi, obci, obcí, obcích.
         // The correct linguistic root is the -ec forms, but we map to -c as it
         // seems much harder to reliably map the various -c- forms to -ec.
         test non-v
         delete attach 'c'
         try palatalise_e
+      )
+      'ek'
+      ( // Conflate e.g. článek with článkem, článku, článků, článkům, články.
+        // The correct linguistic root is the -ek forms, but we map to -k as it
+        // seems much harder to reliably map the various -k- forms to -ek.
+        test non-v
+        not among (
+          'dot' // dotek
+          'obl' // oblek
+          'sn' // česnek
+        )
+        <-'k'
       )
       '{tv}' '{tv}mi'
       ( // Conflate e.g. oběť and oběťmi with obětech; hradišť with hradišti.

--- a/algorithms/czech.sbl
+++ b/algorithms/czech.sbl
@@ -1,7 +1,7 @@
 routines (
   R1
   palatalise_e
-  palatalise_ecaron_or_iacute
+  palatalise_ecaron
   palatalise_i
   mark_regions
   possessive_suffix
@@ -80,7 +80,7 @@ backwardmode (
     )
   )
 
-  define palatalise_ecaron_or_iacute as (
+  define palatalise_ecaron as (
     [substring] among (
       '{c^}t' (<- 'ck')
       '{s^}t' (<- 'sk')
@@ -122,7 +122,7 @@ backwardmode (
       '{e^}m' // e.g. koněm
       (
         delete
-        try palatalise_ecaron_or_iacute
+        try palatalise_ecaron
       )
       'e' 'ech' 'em' 'emi' 'ete' 'etem'
       (
@@ -130,14 +130,10 @@ backwardmode (
         try palatalise_e
       )
       'i'
-      (
-        delete
-        try palatalise_i
-      )
       '{i'}' '{i'}ch' '{i'}ho' '{i'}m' '{i'}mi' '{i'}mu'
       (
         delete
-        try palatalise_ecaron_or_iacute
+        try palatalise_i
       )
     )
   )

--- a/algorithms/czech.sbl
+++ b/algorithms/czech.sbl
@@ -11,7 +11,7 @@ externals ( stem )
 
 integers ( p1 x )
 
-groupings ( ev_ending v v_or_syllabic_c )
+groupings ( env_ending ev_ending v v_or_syllabic_c )
 
 stringescapes {}
 
@@ -47,6 +47,10 @@ define v_or_syllabic_c v + 'lr'
 // Letters that can occur before -ev.  Actual known exceptions include
 // 'j' (objev, projev, výjev) and 'ř' (ohřev)
 define ev_ending 'hknrtz'
+
+// Letters that can occur before -eň.  Actual known exceptions include
+// 'g' (Irgeň), 'l' (zeleň), 'm' (kameň) and 'ř' (třeň).
+define env_ending 'bcdhkščžprstvz'
 
 define mark_regions as (
 
@@ -161,6 +165,21 @@ backwardmode (
         )
         <-'k'
       )
+      'e{nv}'
+      ( // Conflate e.g. Plzeň with Plzně, Plzni, Plzní.
+        // The correct linguistic root is the -eň form, but we map to -n as
+        // that's easier to do reliably than to map the other way.
+        test env_ending
+        <-'n' // -eň -> -n not -ň
+      )
+      // -eš can also lose the -e- but this seems very uncommon - the only
+      // example I've seen is Aleš (a male given name or diminuitive name)
+      // which can decline as Alše or Aleše, etc.  These alternative
+      // declensions mean that just removing the -e- from Aleš would not
+      // really help (especially as the forms which keep the -e- seem
+      // more common, at least based on cs.wikipedia.org) so if we did this
+      // we would need to also remove -e- from Aleše, etc, which seems a lot
+      // of complication for a single word.
       'et'
       ( // Conflate e.g. počet with počte, počtu, počty, etc.
         // The correct linguistic root is the -et form, but we map to -t as

--- a/algorithms/czech.sbl
+++ b/algorithms/czech.sbl
@@ -11,7 +11,7 @@ externals ( stem )
 
 integers ( p1 x )
 
-groupings ( v v_or_syllabic_c )
+groupings ( ev_ending v v_or_syllabic_c )
 
 stringescapes {}
 
@@ -43,6 +43,10 @@ define v 'aeiouy{a'}{ev}{e'}{i'}{o'}{u'}{uo}{y'}'
 // vocabulary list (also from wikipedia but with a lower cut-off frequency)
 // all but one of the affected words don't seem to actually be Czech words.
 define v_or_syllabic_c v + 'lr'
+
+// Letters that can occur before -ev.  Actual known exceptions include
+// 'j' (objev, projev, výjev) and 'ř' (ohřev)
+define ev_ending 'hknrtz'
 
 define mark_regions as (
 
@@ -169,6 +173,13 @@ backwardmode (
           'kar' // e.g. karet but not cigaret.
         )
         <-'t'
+      )
+      'ev'
+      ( // Conflate e.g. církev with církve, církve, církvemu, církví, etc.
+        // The correct linguistic root is the -ev form, but we map to -v as
+        // that's easier to do reliably than to map the other way.
+        ev_ending
+        <-'v'
       )
       '{tv}' '{tv}mi'
       ( // Conflate e.g. oběť and oběťmi with obětech; hradišť with hradišti.

--- a/algorithms/czech.sbl
+++ b/algorithms/czech.sbl
@@ -82,14 +82,14 @@ backwardmode (
 
   define palatalise_e as (
     [substring] among (
-      'c' '{cv}' (<- 'k')
+      'c' (<- 'k')
       'z' '{zv}' (<- 'h')
     )
   )
 
   define palatalise_i as (
     [substring] among (
-      'c' '{cv}' (<- 'k')
+      'c' (<- 'k')
       'z' '{zv}' (<- 'h')
       '{cv}t' (<- 'ck')
       // -št -> -sk

--- a/algorithms/czech.sbl
+++ b/algorithms/czech.sbl
@@ -47,9 +47,9 @@ define v_or_syllabic_c v + 'lr'
 
 define mark_regions as (
 
-    $p1 = limit
-    test(hop 3 setmark x)
+    test (hop 3 setmark x) // Signals f if the input < 3 characters.
 
+    $p1 = limit
     do (
         // A syllabic consonant must occur between two consonants, or be
         // preceded by a consonant and at the end of the word.
@@ -140,7 +140,7 @@ backwardmode (
 )
 
 define stem as (
-  do mark_regions
+  mark_regions // Signals f if the input has < 3 characters.
   backwards (
     do case_suffix
     do possessive_suffix

--- a/algorithms/czech.sbl
+++ b/algorithms/czech.sbl
@@ -139,24 +139,18 @@ backwardmode (
       )
       'eb'
       ( // Conflate e.g. skladeb with skladba, skladbě, skladby, etc.
-        // The correct linguistic root is the -eb form, but we map to -b as
-        // that's easier to do reliably than to map the other way.
         test non-v
         not 't{rv}' // potřeb
         <-'b'
       )
       'ec'
       ( // Conflate e.g. obec with obce, obcemi, obci, obcí, obcích.
-        // The correct linguistic root is the -ec form, but we map to -c as
-        // that's easier to do reliably than to map the other way.
         test non-v
         delete attach 'c'
         try palatalise_e
       )
       'ek'
       ( // Conflate e.g. článek with článkem, článku, článků, článkům, články.
-        // The correct linguistic root is the -ek form, but we map to -k as
-        // that's easier to do reliably than to map the other way.
         test non-v
         not among (
           'dot' // dotek
@@ -165,16 +159,21 @@ backwardmode (
         )
         <-'k'
       )
+      '{ev}k'
+      ( // Conflate e.g. daněk with daňka, daňkem, daňki, daňkovi, daňků, etc.
+        'n'] <-'{nv}k'
+      )
       'e{nv}'
       ( // Conflate e.g. Plzeň with Plzně, Plzni, Plzní.
-        // The correct linguistic root is the -eň form, but we map to -n as
-        // that's easier to do reliably than to map the other way.
         test env_ending
         <-'n' // -eň -> -n not -ň
       )
       // -eš can also lose the -e- but this seems very uncommon - the only
       // example I've seen is Aleš (a male given name or diminuitive name)
-      // which can decline as Alše or Aleše, etc.  These alternative
+      // but we require 3 characters before R1 so this won't be considered
+      // for stemming.
+      //
+      // Also this can decline as Alše or Aleše, etc, and these alternative
       // declensions mean that just removing the -e- from Aleš would not
       // really help (especially as the forms which keep the -e- seem
       // more common, at least based on cs.wikipedia.org) so if we did this
@@ -182,8 +181,6 @@ backwardmode (
       // of complication for a single word.
       'et'
       ( // Conflate e.g. počet with počte, počtu, počty, etc.
-        // The correct linguistic root is the -et form, but we map to -t as
-        // that's easier to do reliably than to map the other way.
         among (
           'uc' // e.g. tucet but not dvacet.
           '{cv}'
@@ -195,8 +192,6 @@ backwardmode (
       )
       'ev'
       ( // Conflate e.g. církev with církve, církve, církvemu, církví, etc.
-        // The correct linguistic root is the -ev form, but we map to -v as
-        // that's easier to do reliably than to map the other way.
         ev_ending
         <-'v'
       )

--- a/algorithms/czech.sbl
+++ b/algorithms/czech.sbl
@@ -50,7 +50,7 @@ define ev_ending 'hknrtz'
 
 // Letters that can occur before -eň.  Actual known exceptions include
 // 'g' (Irgeň), 'l' (zeleň), 'm' (kameň) and 'ř' (třeň).
-define env_ending 'bcdhkščžprstvz'
+define env_ending 'bc{cv}dhkprs{sv}tvz{zv}'
 
 define mark_regions as (
 

--- a/algorithms/czech.sbl
+++ b/algorithms/czech.sbl
@@ -157,15 +157,15 @@ backwardmode (
       (
         // t-stem neuter nouns
         among (
-          '{cv}'  // e.g. dvojčetem
-          'l'     // e.g. batolete
-          '{rv}'  // e.g. zvířete
-          's'     // e.g. prasete
-          '{zv}'  // e.g. pážete
+          '{cv}'  // e.g. dvojč-etem
+          'l'     // e.g. batol-ete
+          '{rv}'  // e.g. zvíř-ete
+          's'     // e.g. pras-ete
+          '{zv}'  // e.g. páž-ete
               (delete)
-          'e{cv}' // e.g. pečeti
-          'tl'    // e.g. atleti
-          'es'    // e.g. deseti
+          'e{cv}' // e.g. pečet-i
+          'tl'    // e.g. atlet-i
+          'es'    // e.g. deset-i
           ''
               (
                 // Remove -e, -i, or -em; stem now ends -et so no palatalise

--- a/algorithms/czech.sbl
+++ b/algorithms/czech.sbl
@@ -148,10 +148,31 @@ backwardmode (
       (
         delete
       )
-      'e' 'ech' 'em' 'emi' 'ete' 'etem'
+      'e' 'ech' 'em' 'emi'
       (
         delete
         try palatalise_e
+      )
+      'ete' 'eti' 'etem'
+      (
+        // t-stem neuter nouns
+        among (
+          '{cv}'  // e.g. dvojčetem
+          'l'     // e.g. batolete
+          '{rv}'  // e.g. zvířete
+          's'     // e.g. prasete
+          '{zv}'  // e.g. pážete
+              (delete)
+          'e{cv}' // e.g. pečeti
+          'tl'    // e.g. atleti
+          'es'    // e.g. deseti
+          ''
+              (
+                // Remove -e, -i, or -em; stem now ends -et so no palatalise
+                // step is needed.
+                <-'et'
+              )
+        )
       )
       'eb'
       ( // Conflate e.g. skladeb with skladba, skladbě, skladby, etc.

--- a/algorithms/czech.sbl
+++ b/algorithms/czech.sbl
@@ -82,14 +82,32 @@ backwardmode (
 
   define palatalise_e as (
     [substring] among (
-      'c' (<- 'k')
+      // -c -> -k
+      'c'
+        (<- 'k')
+      'nc' // e.g. finance
+      'avc' // e.g. dravce
+      'ovc' // e.g. jalovce
+        ()
+      '{i'}nc' // e.g. podmínce
+        (<- '{i'}nk')
     )
   )
 
   define palatalise_i as (
     [substring] among (
-      'c' (<- 'k')
+      // -c -> -k
+      'c'
+        (<- 'k')
+      'nc' // e.g. financí
+      'avc' // e.g. nástavci
+      'ovc' // e.g. pískovci
+        ()
+      '{i'}nc' // e.g. podmínce
+        (<- '{i'}nk')
+
       '{cv}t' (<- 'ck')
+
       // -št -> -sk
       '{sv}t' // e.g. čeština
         (<-'sk')

--- a/libstemmer/modules.txt
+++ b/libstemmer/modules.txt
@@ -13,6 +13,7 @@ arabic          UTF_8                   arabic,ar,ara
 armenian        UTF_8                   armenian,hy,hye,arm
 basque          UTF_8,ISO_8859_1        basque,eu,eus,baq
 catalan         UTF_8,ISO_8859_1        catalan,ca,cat
+czech           UTF_8,ISO_8859_2        czech,cs,ces,cze
 danish          UTF_8,ISO_8859_1        danish,da,dan
 dutch           UTF_8,ISO_8859_1        dutch,nl,dut,nld,kraaij_pohlmann
 english         UTF_8,ISO_8859_1        english,en,eng


### PR DESCRIPTION
This has been on the web site since 2012, but never actually got
included in the code distribution.

Points to resolve:

- [x] R1 and RV
  - [x] syllabic constants in definitions (r, l, maybe m, maybe n). https://github.com/snowballstem/snowball/pull/151#issuecomment-2303057423
  - [x] when to apply them
 - [x] `č` suffix in snowball vs `če` in Java (Snowball seems to have copied `-č` typo in Java comment)
 - [x] `čtí`/`ští` in Java vs `čté`/`šté` in Snowball (again seems to be due to Java comment typo)
 - [x] `len- 2` instead of `len- 3` for Java `ště`/`šti`/`ští` check. Seems fairly clear improvement.
 - [x] Snowball version removes extra character before calling `palatalise`.
 - [x] Snowball version doesn't remove final character by default if `palatalise` doesn't otherwise match.
 - [x] if `do_case` doesn't make a replacement then `do_possessive` won't get called, but in the java code, `removePossessives` is always called. https://github.com/snowballstem/snowball/pull/151#issuecomment-1791896886
 - [x] Java version leaves the first character of a removed suffix behind when calling `palatalise` **except** for `-es`/`-ém`/`-ím`
 - [x] `setlimit tomark p1 for ([substring])` vs `[substring] R1`
 - [x] Look into addressing unhelpful splits from palatalise change
 - [x] `-ětem` isn't listed by https://en.wikipedia.org/wiki/Czech_declension but seems to be valid from e.g. https://en.wiktionary.org/wiki/hrab%C4%9B https://en.wiktionary.org/wiki/markrab%C4%9B and https://en.wiktionary.org/wiki/ml%C3%A1d%C4%9B
 - [x] `-os`, `-es`, `-iho`, `-imu` aren't listed by https://en.wikipedia.org/wiki/Czech_declension
 - [x] `-ich` seems to only be a suffix for two pronouns
 - [x] Should we also remove `-ima`? Probably not.
 - [x] Should we also remove `-ímu` (with a diacritic on the `i`)? Yes.
 - [x] Java light stemmer removes `-ěte` and `-ěti` while the aggressive stemmer removes `-ete` and `-eti` (no caron on the e). The snowball implementation follows the light stemmer. The older version of the light stemmer listed in the original paper removes all four suffixes. Analysis in https://github.com/snowballstem/snowball/pull/151#issuecomment-1788329521 suggests maybe to leave as-is? Probably this was trying to make the stemmer partly ignore diacritics, see next point.
 - [x] Change stemmer to remove diacritics? Seems too hard.
 - [x] `{ desce desk deska deskami deskou desková deskové deskový deskových desku desky deskách } + { dešti deštích deště }` - seems to be conflating "plate" and "rain"; simple tests suggest this (and numerous other conflations due to palatalise) are fixable my imposing some sort of region check on the palatalise step, but need to experiment to determine what region definition is appropriate (and whether it should the same for all palatalise replacements)
 - [x] _červencem_ ("July") stems to `červenk` but so does _červenka_ ("robin"); also some other forms of "July" such as _červencový_ stem to `červenc`.  There is an inherent ambiguity here as _července_ is a form of both words, but it's bad that we make this worse.
 - [ ] Review restoring more limited versions of the removed palatalise rules.