### PR TITLE
Add special cases for the two (!) legal pluralizations of "bus"

### DIFF
--- a/algorithms/english.sbl
+++ b/algorithms/english.sbl
@@ -176,6 +176,8 @@ define exception1 as (
         'dying'     (<-'die')
         'lying'     (<-'lie')
         'tying'     (<-'tie')
+        'busses'    (<-'bus')
+        'buses'     (<-'bus')
 
         /* special -LY cases */
 


### PR DESCRIPTION
Found by a PostgreSQL user trying to search for various transit words using full text search. Seems like a genuine corner case? I cannot thing of another word with the same pluralization pattern.