### PR TITLE
fix a memleak in snowball compiler

### DIFF
--- a/compiler/driver.c
+++ b/compiler/driver.c
@@ -146,8 +146,17 @@ static int read_options(struct options * o, int argc, char * argv[]) {
                 continue;
             }
             if (eq(s, "-n") || eq(s, "-name")) {
+                char * new_name;
+                size_t len;
+
                 check_lim(i, argc);
-                o->name = argv[i++];
+                /* Take a copy of the argument here, because
+                 * later we will free o->name */
+                len = strlen(argv[i]);
+                new_name = malloc(len + 1);
+                memcpy(new_name, argv[i++], len);
+                new_name[len] = '\0';
+                o->name = new_name;
                 continue;
             }
 #ifndef DISABLE_JS
@@ -599,6 +608,7 @@ extern int main(int argc, char * argv[]) {
             lose_b(p->b); FREE(p); p = q;
         }
     }
+    FREE(o->name);
     FREE(o);
     if (space_count) fprintf(stderr, "%d blocks unfreed\n", space_count);
     return 0;

--- a/compiler/header.h
+++ b/compiler/header.h
@@ -338,7 +338,7 @@ struct options {
     /* for the command line: */
 
     const char * output_file;
-    const char * name;
+    char * name;
     FILE * output_src;
     FILE * output_h;
     byte syntax_tree;


### PR DESCRIPTION
When an output file is used and the name option is not, then the
compiler will dynamically allocate value for the `name` option and never
free it.
This is not a large problem, because at the end of the compile process
the OS will free all allocated memory anyway.
However, when using snowball as part of a larger toolchain and then
using compile options such as `-fsanitize=leak`, a memleak in snowball
can break the entire build.
This exactly what happened to us. We could work around this somehow, but
it seems better to fix the leak in the compiler properly.

The same issue was already reported previously by a former colleague of
mine in https://github.com/snowballstem/snowball/pull/136, but that PR
seemingly was disliked by the snowball maintainers. Trying it again with
this PR with a slightly modified solution and hope it can be merged now.