### PR TITLE
Fix romanian stemmer to work with unicode alphabet in modern use

### DIFF
--- a/algorithms/romanian.sbl
+++ b/algorithms/romanian.sbl
@@ -1,5 +1,6 @@
 
 routines (
+           norm
            prelude postlude mark_regions
            RV R1 R2
            step_0
@@ -23,10 +24,22 @@ stringescapes {}
 stringdef a^   '{U+00E2}'  // a circumflex
 stringdef i^   '{U+00EE}'  // i circumflex
 stringdef a+   '{U+0103}'  // a breve
-stringdef s,   '{U+015F}'  // s cedilla
-stringdef t,   '{U+0163}'  // t cedilla
+stringdef s~   '{U+015F}'  // s cedilla
+stringdef t~   '{U+0163}'  // t cedilla
+stringdef s,   '{U+0219}'  // s comma
+stringdef t,   '{U+021B}'  // t comma
 
 define v 'aeiou{a^}{i^}{a+}'
+
+// normalize s~ to s, and t~ to t,
+define norm as (
+    do repeat goto (
+        [substring] among (
+            '{s~}'    (<- '{s,}')
+            '{t~}'    (<- '{t,}')
+        )
+    )
+)
 
 define prelude as (
     repeat goto (
@@ -223,6 +236,7 @@ backwardmode (
 )
 
 define stem as (
+    do norm
     do prelude
     do mark_regions
     backwards (

--- a/libstemmer/modules.txt
+++ b/libstemmer/modules.txt
@@ -29,7 +29,7 @@ lithuanian      UTF_8                   lithuanian,lt,lit
 nepali          UTF_8                   nepali,ne,nep
 norwegian       UTF_8,ISO_8859_1        norwegian,no,nor
 portuguese      UTF_8,ISO_8859_1        portuguese,pt,por
-romanian        UTF_8,ISO_8859_2        romanian,ro,rum,ron
+romanian        UTF_8                   romanian,ro,rum,ron
 russian         UTF_8,KOI8_R            russian,ru,rus
 serbian         UTF_8                   serbian,sr,srp
 spanish         UTF_8,ISO_8859_1        spanish,es,esl,spa


### PR DESCRIPTION
Currently the stemmer does not work with s-comma and t-comma characters, but only with their cedilla "approximations" from before Romanian had full Unicode support.

The problem is that these cedilla "approximations" are no longer much in use: you can still find them but the frequency is much lower. For example, when analyzing the character counts of Romanian wikipedia:
```
proper comma forms
        U+0218  Ș       129164
        U+0219  ș       1602600
        U+021A  Ț       21578
        U+021B  ț       1088506

old cedilla forms
        U+015E  Ş       1007
        U+015F  ş       34008
        U+0162  Ţ       465
        U+0163  ţ       52129
```

With this change, the old cedilla "approximations" are normalized to the proper unicode characters by the stemmer, so the expected output changes.

For more information, see:
* https://en.wikipedia.org/wiki/%C8%98
* https://en.wikipedia.org/wiki/%C8%9A