### PR TITLE
Added python_requires for Python package; Removed Python 2.6

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -45,11 +45,12 @@ for lang in langs:
     if lang_titlecase not in ('Armenian', 'Yiddish'):
         classifiers.append('Natural Language :: ' + lang_titlecase)
 
+python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*'
+
 classifiers.extend([
     'Operating System :: OS Independent',
     'Programming Language :: Python',
     'Programming Language :: Python :: 2',
-    'Programming Language :: Python :: 2.6',
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.4',


### PR DESCRIPTION
For details, see the commit message.
This addresses issue #191.

I did not know where to update the change history, as the NEWS file seems to have only the changes for released versions, but not for those in development. I think something like this should be added to the NEWS file once released:

```
Python
-------

* Specified supported Python versions via `python_requires` so that they can be
  recognized by Python installers.

* Removed Python 2.6 from the versions documented in the Trove classifiers.
```
