### PR TITLE
Java performance improvements from Apache Lucene

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -12,7 +12,7 @@ c_src_dir = src_c
 
 JAVACFLAGS ?=
 JAVAC ?= javac
-JAVA ?= java
+JAVA ?= java -ea
 java_src_main_dir = java/org/tartarus/snowball
 java_src_dir = $(java_src_main_dir)/ext
 

--- a/compiler/generator_java.c
+++ b/compiler/generator_java.c
@@ -272,7 +272,7 @@ static void generate_AE(struct generator * g, struct node * p) {
             break;
         case c_len: /* Same as size() for Java. */
         case c_size:
-            w(g, "current.length()");
+            w(g, "limit");
             break;
     }
 }
@@ -977,9 +977,12 @@ static void generate_define(struct generator * g, struct node * p) {
      * be required to allow the SnowballProgram base class to invoke them.
      * FIXME: Is this avoidable?
      */
-    if (q->type == t_routine && !q->used_in_among) {
+    if (q->used_in_among) {
+        g->S[0] = "public";
+    } else if (q->type == t_routine) {
         g->S[0] = "private";
     } else {
+        w(g, "~N~M@Override");
         g->S[0] = "public";
     }
     g->V[0] = q;
@@ -1192,6 +1195,7 @@ static void generate_class_begin(struct generator * g) {
     w(g, " {~+~N"
          "~N"
          "~Mprivate static final long serialVersionUID = 1L;~N"
+         "~Mprivate static final java.lang.invoke.MethodHandles.Lookup methodObject = java.lang.invoke.MethodHandles.lookup();~N"
          "~N");
 }
 
@@ -1238,7 +1242,7 @@ static void generate_among_table(struct generator * g, struct among * x) {
             if (v->function != 0) {
                 w(g, ", \"");
                 write_varname(g, v->function);
-                w(g, "\", ~n.class");
+                w(g, "\", methodObject");
             }
             w(g, ")~S0~N");
             v++;

--- a/compiler/generator_java.c
+++ b/compiler/generator_java.c
@@ -272,7 +272,7 @@ static void generate_AE(struct generator * g, struct node * p) {
             break;
         case c_len: /* Same as size() for Java. */
         case c_size:
-            w(g, "limit");
+            w(g, "length");
             break;
     }
 }

--- a/java/org/tartarus/snowball/Among.java
+++ b/java/org/tartarus/snowball/Among.java
@@ -1,7 +1,13 @@
 package org.tartarus.snowball;
 
-import java.lang.reflect.Method;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.Locale;
 
+/**
+ * Internal class used by Snowball stemmers
+ */
 public class Among {
     public Among (String s, int substring_i, int result) {
         this.s = s.toCharArray();
@@ -11,19 +17,30 @@ public class Among {
     }
 
     public Among (String s, int substring_i, int result, String methodname,
-		  Class<? extends SnowballProgram> programclass) {
+		  MethodHandles.Lookup methodobject) {
         this.s = s.toCharArray();
         this.substring_i = substring_i;
 	this.result = result;
-	try {
-	    this.method = programclass.getDeclaredMethod(methodname);
-	} catch (NoSuchMethodException e) {
-	    throw new RuntimeException(e);
-	}
+	final Class<? extends SnowballProgram> clazz = methodobject.lookupClass().asSubclass(SnowballProgram.class);
+	if (methodname.length() > 0) {
+	    try {
+	        this.method = methodobject.findVirtual(clazz, methodname, MethodType.methodType(boolean.class))
+	            .asType(MethodType.methodType(boolean.class, SnowballProgram.class));
+	    } catch (NoSuchMethodException | IllegalAccessException e) {
+	        throw new RuntimeException(String.format(Locale.ENGLISH,
+	            "Snowball program '%s' is broken, cannot access method: boolean %s()",
+	            clazz.getSimpleName(), methodname
+	        ), e);
+	    }
+	} else {
+	    this.method = null;
+        }
     }
 
-    public final char[] s; /* search string */
-    public final int substring_i; /* index to longest matching substring */
-    public final int result; /* result of the lookup */
-    public final Method method; /* method to use if substring matches */
+    final char[] s; /* search string */
+    final int substring_i; /* index to longest matching substring */
+    final int result; /* result of the lookup */
+
+    // Make sure this is not accessible outside package for Java security reasons!
+    final MethodHandle method; /* method to use if substring matches */
 };

--- a/java/org/tartarus/snowball/SnowballProgram.java
+++ b/java/org/tartarus/snowball/SnowballProgram.java
@@ -9,7 +9,6 @@ import java.io.Serializable;
 public class SnowballProgram implements Serializable {
     protected SnowballProgram()
     {
-	current = new char[8];
 	setCurrent("");
     }
 

--- a/java/org/tartarus/snowball/SnowballProgram.java
+++ b/java/org/tartarus/snowball/SnowballProgram.java
@@ -2,6 +2,7 @@
 package org.tartarus.snowball;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.io.Serializable;
+import java.util.Arrays;
 
 /**
  * Base class for a snowball stemmer
@@ -313,16 +314,6 @@ public class SnowballProgram implements Serializable {
 	}
     }
 
-    // mini version of ArrayUtil.oversize from lucene, specialized to chars
-    static int oversize(int minTargetSize) {
-	int extra = minTargetSize >> 3;
-	if (extra < 3) {
-	    extra = 3;
-	}
-	int newSize = minTargetSize + extra;
-	return (newSize + 3) & 0x7ffffffc;
-    }
-
     /* to replace chars between c_bra and c_ket in current by the
      * chars in s.
      */
@@ -332,9 +323,7 @@ public class SnowballProgram implements Serializable {
 	final int newLength = limit + adjustment;
 	//resize if necessary
 	if (newLength > current.length) {
-	    char[] newBuffer = new char[oversize(newLength)];
-	    System.arraycopy(current, 0, newBuffer, 0, limit);
-	    current = newBuffer;
+	    current = Arrays.copyOf(current, newLength);
 	}
 	// if the substring being replaced is longer or shorter than the
 	// replacement, need to shift things around

--- a/java/org/tartarus/snowball/SnowballProgram.java
+++ b/java/org/tartarus/snowball/SnowballProgram.java
@@ -28,7 +28,7 @@ public class SnowballProgram implements Serializable {
      */
     public String getCurrent()
     {
-        return new String(current, 0, limit);
+        return new String(current, 0, length);
     }
 
     /**
@@ -344,12 +344,10 @@ public class SnowballProgram implements Serializable {
 
     protected void slice_check()
     {
-	if (bra < 0 ||
-	    bra > ket ||
-	    ket > limit)
-	{
-	     throw new IllegalArgumentException("faulty slice operation: bra=" + bra + ",ket=" + ket + ",limit=" + limit);
-	}
+	assert bra >= 0 : "bra=" + bra;
+	assert bra <= ket : "bra=" + bra + ",ket=" + ket;
+	assert limit <= length : "limit=" + limit + ",length=" + length;
+	assert ket <= limit : "ket=" + ket + ",limit=" + limit;
     }
 
     protected void slice_from(CharSequence s)

--- a/java/org/tartarus/snowball/SnowballProgram.java
+++ b/java/org/tartarus/snowball/SnowballProgram.java
@@ -20,12 +20,7 @@ public class SnowballProgram implements Serializable {
      */
     public void setCurrent(String value)
     {
-	current = value.toCharArray();
-	cursor = 0;
-	limit = value.length();
-	limit_backward = 0;
-	bra = cursor;
-	ket = limit;
+	setCurrent(value.toCharArray(), value.length());
     }
 
     /**
@@ -44,7 +39,7 @@ public class SnowballProgram implements Serializable {
     public void setCurrent(char[] text, int length) {
         current = text;
         cursor = 0;
-        limit = length;
+        this.length = limit = length;
         limit_backward = 0;
         bra = cursor;
         ket = limit;
@@ -74,13 +69,14 @@ public class SnowballProgram implements Serializable {
      * @return valid length of the array.
      */
     public int getCurrentBufferLength() {
-        return limit;
+        return length;
     }
 
     // current string
     private char[] current;
 
     protected int cursor;
+    protected int length;
     protected int limit;
     protected int limit_backward;
     protected int bra;
@@ -89,6 +85,7 @@ public class SnowballProgram implements Serializable {
     public SnowballProgram(SnowballProgram other) {
 	current          = other.current;
 	cursor           = other.cursor;
+	length           = other.length;
 	limit            = other.limit;
 	limit_backward   = other.limit_backward;
 	bra              = other.bra;
@@ -99,6 +96,7 @@ public class SnowballProgram implements Serializable {
     {
 	current          = other.current;
 	cursor           = other.cursor;
+	length           = other.length;
 	limit            = other.limit;
 	limit_backward   = other.limit_backward;
 	bra              = other.bra;
@@ -320,16 +318,16 @@ public class SnowballProgram implements Serializable {
     protected int replace_s(int c_bra, int c_ket, CharSequence s)
     {
 	final int adjustment = s.length() - (c_ket - c_bra);
-	final int newLength = limit + adjustment;
+	final int newLength = length + adjustment;
 	//resize if necessary
 	if (newLength > current.length) {
 	    current = Arrays.copyOf(current, newLength);
 	}
 	// if the substring being replaced is longer or shorter than the
 	// replacement, need to shift things around
-	if (adjustment != 0 && c_ket < limit) {
+	if (adjustment != 0 && c_ket < length) {
 	    System.arraycopy(current, c_ket, current, c_bra + s.length(),
-	        limit - c_ket);
+	        length - c_ket);
 	}
 	// insert the replacement text
 	// Note, faster is s.getChars(0, s.length(), current, c_bra);
@@ -337,6 +335,7 @@ public class SnowballProgram implements Serializable {
 	for (int i = 0; i < s.length(); i++)
 	    current[c_bra + i] = s.charAt(i);
 
+	length += adjustment;
 	limit += adjustment;
 	if (cursor >= c_ket) cursor += adjustment;
 	else if (cursor > c_bra) cursor = c_bra;

--- a/java/org/tartarus/snowball/SnowballStemmer.java
+++ b/java/org/tartarus/snowball/SnowballStemmer.java
@@ -1,6 +1,9 @@
 
 package org.tartarus.snowball;
 
+/**
+ * Parent class of all snowball stemmers, which must implement <code>stem</code>
+ */
 public abstract class SnowballStemmer extends SnowballProgram {
     public abstract boolean stem();
 

--- a/java/org/tartarus/snowball/TestApp.java
+++ b/java/org/tartarus/snowball/TestApp.java
@@ -12,6 +12,7 @@ import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 
 public class TestApp {
     private static void usage()
@@ -66,20 +67,24 @@ public class TestApp {
 	Writer output = new OutputStreamWriter(outstream, StandardCharsets.UTF_8);
 	output = new BufferedWriter(output);
 
-	StringBuffer input = new StringBuffer();
+	char [] input = new char[8];
+	int length = 0;
 	int character;
 	while ((character = reader.read()) != -1) {
 	    char ch = (char) character;
 	    if (Character.isWhitespace(ch)) {
-		stemmer.setCurrent(input.toString());
+		stemmer.setCurrent(input, length);
 		stemmer.stem();
-		output.write(stemmer.getCurrent());
+		output.write(stemmer.getCurrentBuffer(), 0, stemmer.getCurrentBufferLength());
 		output.write('\n');
-		input.delete(0, input.length());
+		length = 0;
 	    } else {
-		input.append(ch < 127 ? Character.toLowerCase(ch) : ch);
+		if (length == input.length) {
+			input = Arrays.copyOf(input, length + 1);
+		}
+		input[length++] = ch < 127 ? Character.toLowerCase(ch) : ch;
 	    }
 	}
-	output.flush();
+	output.close();
     }
 }


### PR DESCRIPTION
This is long overdue...

* Remove StringBuilder and use simple `char[]` to reduce allocations and overhead.
* Allow use of stemmers without unnecessary memory allocations via additional methods
* Use `MethodHandle.invokeExact()` instead of reflection.

The changes mean that users will need java 7 at a minimum, but since java 7 version is long EOL, I don't think it will cause anyone grief.

Users can still use `setCurrent(String) ... stem() ... getCurrent()`, but this adds support for a higher-performance approach: `setCurrent(char[], int), getCurrentBuffer(), stem() ... getCurrentBuffer()/getCurrentBufferLength()`

This avoids many per-word object allocations:
* Caller no longer forced to create a new `String` for every input word.
* The backing `byte[]/char[]` of that `String` they were forced to create.
* The StringBuilder previously created by snowball for every word.
* The backing `char[]` for that StringBuilder.
* Resulting `String` when they retrieve the result.

When indexing documents, all these per-word allocations put too much pressure on garbage collection and bottleneck performance.