### PR TITLE
api: fixed potential NULL dereference

### DIFF
--- a/runtime/api.c
+++ b/runtime/api.c
@@ -36,7 +36,7 @@ error:
 extern void SN_close_env(struct SN_env * z, int S_size)
 {
     if (z == NULL) return;
-    if (S_size)
+    if (z->S && S_size)
     {
         int i;
         for (i = 0; i < S_size; i++)


### PR DESCRIPTION
If we transfer control to the SN_create_env() function by using the error label when there is a memory allocation error of z->p or z->S, we can then dereference the NULL pointer z->S in the function SN_close_env(). Added the pointer check for avoiding potential problem.

Found by Postgres Pro with Svace static analyzer
Fixes: e9dd099 ("This module will contain only the code and build system, and documentation for building and running the stemming library. All sample data will be in a separate module, and the website will be in its own module too.")