### PR TITLE
Fix warnings when generating Python dist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,7 @@ jobs:
     - name: Test C dist
       if: matrix.CFLAGS_DIST_BUILD
       run: |
-        pip install setuptools
+        pip install setuptools build
         $MAKE dist
         mkdir tmp
         cd tmp

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -477,7 +477,7 @@ dist_libstemmer_python: $(PYTHON_SOURCES) $(COMMON_FILES)
 	cp -a $(PYTHON_SAMPLE_SOURCES) $${dest}/src/$(python_sample_dir) && \
 	cp -a $(PYTHON_RUNTIME_SOURCES) $${dest}/src/$(python_runtime_dir) && \
 	cp -a $(COMMON_FILES) $(PYTHON_PACKAGE_FILES) $${dest} && \
-	(cd $${dest} && $(python) setup.py sdist bdist_wheel && cp dist/*.tar.gz dist/*.whl ..) && \
+	(cd $${dest} && $(python) -m build && cp dist/*.tar.gz dist/*.whl ..) && \
 	rm -rf $${dest}
 
 dist_libstemmer_js: $(JS_SOURCES) $(COMMON_FILES)

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -1,6 +1,3 @@
 [metadata]
 long_description = file: README.rst
 long_description_content_type = text/x-rst
-
-[bdist_wheel]
-universal=1


### PR DESCRIPTION
When calling `make dist_libstemmer_python` in the current master, these two warnings are printed:

```
/usr/lib/python3/dist-packages/setuptools/_distutils/cmd.py:79: SetuptoolsDeprecationWarning: setup.py install is deprecated.
!!

        ********************************************************************************
        Please avoid running ``setup.py`` directly.
        Instead, use pypa/build, pypa/installer or other
        standards-based tools.

        See https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html for details.
        ********************************************************************************

!!
```

and

```
/usr/lib/python3/dist-packages/setuptools/_distutils/cmd.py:124: SetuptoolsDeprecationWarning: bdist_wheel.universal is deprecated
!!

        ********************************************************************************
        With Python 2.7 end-of-life, support for building universal wheels
        (i.e., wheels that support both Python 2 and Python 3)
        is being obviated.
        Please discontinue using this option, or if you still need it,
        file an issue with pypa/setuptools describing your use case.

        By 2025-Aug-30, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.
        ********************************************************************************

!!
```

This PR has the minimal changes required to fix these warnings.

If you agree, I can improve our Python packaging further in the next PRs:
- Drop support for Python 2 completely and modernize the code using [`pyupgrade`](https://pypi.org/project/pyupgrade/) tool.
- Move the build system metadata from `setup.py` and `setup.cfg` to `pyproject.toml`. There is a dynamic part of metadata (list of languages), but we can either keep that part in `setup.py` (and move the static part only), or make `pyproject.toml` generated by GNUmakefile.