### PR TITLE
python: Set minimum required Python version to 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,8 @@ jobs:
         - name: Pascal
           FPC: fpc
           apt_packages: 'fpc'
-        - name: Python 3.8
-          PYTHON_VERSION: 3.8
+        - name: Python 3.7
+          PYTHON_VERSION: 3.7
           os: 'ubuntu-22.04'
           # The pure Python versions run slowly - when we used travis for CI
           # we used to need to thin the testdata for languages such as Arabic

--- a/python/setup.py
+++ b/python/setup.py
@@ -48,14 +48,7 @@ for lang in langs:
 classifiers.extend([
     'Operating System :: OS Independent',
     'Programming Language :: Python',
-    'Programming Language :: Python :: 2',
-    'Programming Language :: Python :: 2.6',
-    'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.3',
-    'Programming Language :: Python :: 3.4',
-    'Programming Language :: Python :: 3.5',
-    'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
@@ -81,6 +74,6 @@ setup(name='snowballstemmer',
       license="BSD-3-Clause",
       packages=['snowballstemmer'],
       package_dir={"snowballstemmer": "src/snowballstemmer"},
-      python_requires='!=3.0.*, !=3.1.*, !=3.2.*',
+      python_requires='>=3.7',
       classifiers = classifiers
 )


### PR DESCRIPTION
Python 2.7 reached its end of life on 2020-01-01.

Python 3.6 reached its end of life [two years later](https://devguide.python.org/versions/), on 2021-12-23, but that is still more than 3 years ago.

And bumping Python to 3.7 will allow me to upgrade setuptools to 61.2.0, which is the first version to properly support metadata in [`pyproject.toml`](https://packaging.python.org/en/latest/specifications/pyproject-toml/).

Also, replace Python 3.8 with 3.7 in the tests, so that we test both the lower and higher bounds of supported version range.