### PR TITLE
python: Drop Python 2 support, require Python ≥ 3.3

### DIFF
--- a/compiler/generator_python.c
+++ b/compiler/generator_python.c
@@ -56,7 +56,7 @@ static void write_varref(struct generator * g, struct name * p) {
 static void write_literal_string(struct generator * g, symbol * p) {
 
     int i;
-    write_string(g, "u\"");
+    write_char(g, '"');
     for (i = 0; i < SIZE(p); i++) {
         int ch = p[i];
         if (32 <= ch && ch < 127) {
@@ -67,7 +67,7 @@ static void write_literal_string(struct generator * g, symbol * p) {
             write_hex4(g, ch);
         }
     }
-    write_string(g, "\"");
+    write_char(g, '"');
 }
 
 static void write_margin(struct generator * g) {
@@ -294,12 +294,10 @@ static void generate_AE(struct generator * g, struct node * p) {
             /* Snowball specifies integer division with semantics matching C,
              * so Python's `/` or `//` isn't suitable (`//` would be in cases
              * where we knew that the arguments had the same sign).
-             *
-             * The `float(`...`)` is needed for Python2.
              */
-            write_string(g, "int(float(");
+            write_string(g, "int(");
             generate_AE(g, p->left);
-            write_string(g, ") / ");
+            write_string(g, " / ");
             generate_AE(g, p->right);
             write_char(g, ')');
             break;
@@ -955,8 +953,7 @@ static void generate_dollar(struct generator * g, struct node * p) {
         g->outbuf = g->failure_str;
         g->V[0] = p->name;
         writef(g, "~V0 = self.current; ", p);
-        /* For Python 3, this can just be: super().copy_from(~B0) */
-        writef(g, "super(~n, self).copy_from(~B0)", p);
+        writef(g, "super().copy_from(~B0)", p);
         g->failure_str = g->outbuf;
         g->outbuf = saved_output;
     }
@@ -1237,11 +1234,9 @@ static void generate(struct generator * g, struct node * p) {
             /* Snowball specifies integer division with semantics matching C,
              * so Python's `/=` or `//=` isn't suitable (`//=` would be in
              * cases where we knew that the arguments had the same sign).
-             *
-             * The `float(`...`)` is needed for Python2.
              */
             g->V[0] = p->name;
-            w(g, "~M~V0 = int(float(~V0) / ");
+            w(g, "~M~V0 = int(~V0 / ");
             generate_AE(g, p->AE);
             w(g, ")~N");
             break;

--- a/python/setup.py
+++ b/python/setup.py
@@ -48,9 +48,6 @@ for lang in langs:
 classifiers.extend([
     'Operating System :: OS Independent',
     'Programming Language :: Python',
-    'Programming Language :: Python :: 2',
-    'Programming Language :: Python :: 2.6',
-    'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.3',
     'Programming Language :: Python :: 3.4',
@@ -81,6 +78,6 @@ setup(name='snowballstemmer',
       license="BSD-3-Clause",
       packages=['snowballstemmer'],
       package_dir={"snowballstemmer": "src/snowballstemmer"},
-      python_requires='!=3.0.*, !=3.1.*, !=3.2.*',
+      python_requires='>=3.3',
       classifiers = classifiers
 )

--- a/python/snowballstemmer/among.py
+++ b/python/snowballstemmer/among.py
@@ -1,5 +1,4 @@
-
-class Among(object):
+class Among:
     def __init__(self, s, substring_i, result, method=None):
         """
         @ivar s search string

--- a/python/snowballstemmer/basestemmer.py
+++ b/python/snowballstemmer/basestemmer.py
@@ -1,4 +1,4 @@
-class BaseStemmer(object):
+class BaseStemmer:
     def __init__(self):
         self.set_current("")
 

--- a/python/stemwords.py
+++ b/python/stemwords.py
@@ -77,7 +77,7 @@ def stemming(lang, input, output, encoding, pretty):
             for original in infile.readlines():
                 original = original.strip()
                 # Convert only ASCII-letters to lowercase, to match C behavior
-                original = ''.join((c.lower() if 'A' <= c <= 'Z' else c for c in original))
+                original = ''.join(c.lower() if 'A' <= c <= 'Z' else c for c in original)
                 stemmed = stemmer.stemWord(original)
                 if pretty == 0:
                     if stemmed != "":


### PR DESCRIPTION
As discussed in #210 and #211.