### PR TITLE
python: Add a minimal pyproject.toml file

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -135,6 +135,7 @@ PYTHON_SAMPLE_SOURCES = python/testapp.py \
 		        python/stemwords.py
 
 PYTHON_PACKAGE_FILES = python/MANIFEST.in \
+		       python/pyproject.toml \
 		       python/setup.py \
 		       python/setup.cfg
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Quoting [packaging.python.org](https://packaging.python.org/en/latest/discussions/setup-py-deprecated/#is-pyproject-toml-mandatory):

> While it is not technically necessary yet, it is **STRONGLY RECOMMENDED** for a project to have a `pyproject.toml` file at the root of its source tree with a content like this:
>
> ```toml
> [build-system]
> requires = ["setuptools"]
> build-backend = "setuptools.build_meta"
> ```

Setuptools used to be **the** build system for Python, now it is just one of possible build backends. By adding this file, we tell PEP 517 compatible tools (like `build` or `pip`) that we are using setuptools.