### PR TITLE
swedish: Remove -et/-ets in cases where it helps

### DIFF
--- a/algorithms/swedish.sbl
+++ b/algorithms/swedish.sbl
@@ -1,4 +1,5 @@
 routines (
+           et_condition
            mark_regions
            main_suffix
            consonant_pair
@@ -35,6 +36,52 @@ define mark_regions as (
 
 backwardmode (
 
+    define et_condition as (
+        (non-v v not atlimit)
+        and not among (
+            // frihet, nyhet, råhet, trohet
+            'h'
+            // societet
+            'iet'
+            // annuitet; kontinuitet
+            'uit'
+            // alfabet
+            'fab'
+            // autenticitet; elektricitet; kapacitet; metallicitet; publicitet
+            'cit'
+            // graviditet; likviditet; rigiditet
+            'dit'
+            // neutralitet; rivalitet; sexualitet
+            'alit'
+            // flexibilitet; instabilitet; kompatibilitet; mobilitet; variabilitet
+            'ilit'
+            // anonymitet; intimitet; legitimitet
+            'mit'
+            // kommunitet; maskulinitet; modernitet; spontanitet; suveränitet
+            'nit'
+            // epitet; serendipitet
+            'pit'
+            // auktoritet; integritet; majoritet; popularitet; prioritet
+            'rit'
+            // densitet; generositet; intensitet; luminositet; viskositet
+            'sit'
+            // identitet; kvantitet
+            'tit'
+            // aggressivitet; positivitet
+            'ivit'
+            // antikvitet; oblikvitet
+            'kvit'
+            // komplexitet
+            'xit'
+            // komet
+            'kom'
+            // raket
+            'rak'
+            // paket
+            'pak'
+        )
+    )
+
     define main_suffix as (
         setlimit tomark p1 for ([substring])
         among(
@@ -45,7 +92,9 @@ backwardmode (
             'hetens' 'erns' 'at' 'andet' 'het' 'ast'
                 (delete)
             's'
-                (s_ending delete)
+                ( ('et' et_condition ]) or s_ending  delete )
+            'et'
+                ( et_condition delete )
         )
     )
 


### PR DESCRIPTION
Removing -et can't be done unconditionally because many words end in -et where this isn't a suffix.  However it's a very common suffix so it seems worth crafting a more complex condition under which to remove.

Fixes #47