### PR TITLE
Make sure all routines get mangled names in Python

### DIFF
--- a/compiler/generator_python.c
+++ b/compiler/generator_python.c
@@ -37,7 +37,9 @@ static void write_varname(struct generator * g, struct name * p) {
             break;
         case t_routine:
             write_string(g, "__");
-            /* FALLTHRU */
+            write_s(g, p->s);
+            write_string(g, "_r");
+            return;
         default: {
             int ch = "SBIrxg"[p->type];
             write_char(g, ch);


### PR DESCRIPTION
The Python generator uses private mangled names for Snowball routines by prepending `"__"`. Names are only mangled if they being with `"__"` but don’t end with `"__"`. This makes a stemmer crash if an `among` string has a routine whose name ends in `"__"`.

For example, if you put the following in algorithms/esperanto.sbl:
```snowball
routines ( x__ )
externals ( stem )
define x__ as true
define stem as ( [substring] among('x' x__) delete )
```
then run this:
```zsh
make check_python_stemwords
echo xy | python python_check/stemwords.py -c UTF_8 -l esperanto -i /dev/stdin -o /dev/stdout
```
the output ends:
```
AttributeError: 'EsperantoStemmer' object has no attribute '_EsperantoStemmer__r_x__'
```

This PR fixes that bug by ensuring that a Snowball routine’s Python method is always mangled.