### PR TITLE
Stop excluding classifiers for Armenian and Yiddish

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -42,8 +42,8 @@ classifiers = [
 for lang in langs:
     lang_titlecase = lang.title()
     # Only classifiers listed in https://pypi.org/classifiers/ are allowed
-    if lang_titlecase not in ('Armenian', 'Yiddish'):
-        classifiers.append('Natural Language :: ' + lang_titlecase)
+    # Remove them here or submit them to https://github.com/pypa/trove-classifiers
+    classifiers.append('Natural Language :: ' + lang_titlecase)
 
 classifiers.extend([
     'Operating System :: OS Independent',


### PR DESCRIPTION
Thanks to @henryiii's PR pypa/trove-classifiers#215, PyPI now has them.