### PR TITLE
python: Specify correct dependencies for `$(python_output_dir)/__init__.py`

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -314,8 +314,7 @@ $(python_output_dir)/%_stemmer.py: algorithms/%.sbl snowball$(EXEEXT)
 	@mkdir -p $(python_output_dir)
 	./snowball $< -py -o "$(python_output_dir)/$*_stemmer"
 
-$(python_output_dir)/__init__.py: libstemmer/modules.txt
-	@mkdir -p $(python_output_dir)
+$(python_output_dir)/__init__.py: $(libstemmer_algorithms:%=$(python_output_dir)/%_stemmer.py)
 	$(python) python/create_init.py $(python_output_dir)
 
 $(rust_src_dir)/%_stemmer.rs: algorithms/%.sbl snowball$(EXEEXT)


### PR DESCRIPTION
When `python/create_init.py` is called, the `*_stemmer.py` files should already exist, because this script builds a list of languages based on those files.

This fixes broken Python source distribution being produced by `make -j2 dist_libstemmer_python`.

Fixes #229.