### PR TITLE
python: Reduce overhead of forwarding to PyStemmer

### DIFF
--- a/python/create_init.py
+++ b/python/create_init.py
@@ -16,8 +16,8 @@ for pyscript in os.listdir(python_out_folder):
     if (match):
         langname = match.group(1)
         titlecase = re.sub(r"_", "", langname.title())
-        languages.append("    '%(lang)s': %(title)sStemmer," % {'lang': langname, 'title': titlecase})
-        imports.append('from .%(lang)s_stemmer import %(title)sStemmer' % {'lang': langname, 'title': titlecase})
+        languages.append("        '%(lang)s': %(title)sStemmer," % {'lang': langname, 'title': titlecase})
+        imports.append('    from .%(lang)s_stemmer import %(title)sStemmer' % {'lang': langname, 'title': titlecase})
 imports.sort()
 languages.sort()
 
@@ -26,31 +26,26 @@ if len(languages) == 0:
 
 src = '''__all__ = ('language', 'stemmer')
 
-%(imports)s
-
-_languages = {
-%(languages)s
-}
-
 try:
     import Stemmer
-    cext_available = True
+    algorithms = Stemmer.algorithms
+    stemmer = Stemmer.Stemmer
 except ImportError:
-    cext_available = False
+%(imports)s
 
-def algorithms():
-    if cext_available:
-        return Stemmer.algorithms()
-    else:
+    _languages = {
+%(languages)s
+    }
+
+    def algorithms():
         return list(_languages.keys())
 
-def stemmer(lang):
-    if cext_available:
-        return Stemmer.Stemmer(lang)
-    if lang.lower() in _languages:
-        return _languages[lang.lower()]()
-    else:
-        raise KeyError("Stemming algorithm '%%s' not found" %% lang)
+    def stemmer(lang):
+        lang = lang.lower()
+        if lang in _languages:
+            return _languages[lang]()
+        else:
+            raise KeyError("Stemming algorithm '%%s' not found" %% lang)
 ''' % {'imports': '\n'.join(imports), 'languages': '\n'.join(languages)}
 
 with open(os.path.join(python_out_folder, '__init__.py'), 'w') as out:


### PR DESCRIPTION
Only import the pure Python modules if we're going to use them.

Eliminate the cext_available flag variable and instead just assign the PyStemmer functions to their snowballstemmer names, or define the appropriate versions for the pure Python case.