### PR TITLE
Add JavaScript Module support

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -681,6 +681,21 @@ check_js_%: $(STEMMING_DATA)/%
 	fi
 	@rm tmp.txt
 
+	@echo "Checking output of $* stemmer for JS (ESM)"
+	@if test -f '$</voc.txt.gz' ; then \
+	  gzip -dc '$</voc.txt.gz' > tmp.in; \
+	  $(JSRUN) javascript/stemwords.js --esm -l $* -i tmp.in -o tmp.txt; \
+	  rm tmp.in; \
+	else \
+	  $(JSRUN) javascript/stemwords.js --esm -l $* -i $</voc.txt -o tmp.txt; \
+	fi
+	@if test -f '$</output.txt.gz' ; then \
+	  gzip -dc '$</output.txt.gz'|$(DIFF) -u - tmp.txt; \
+	else \
+	  $(DIFF) -u $</output.txt tmp.txt; \
+	fi
+	@rm tmp.txt
+
 ###############################################################################
 # Rust
 ###############################################################################

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -172,7 +172,9 @@ PASCAL_SOURCES = $(ISO_8859_1_algorithms:%=$(pascal_src_dir)/%Stemmer.pas)
 PYTHON_SOURCES = $(libstemmer_algorithms:%=$(python_output_dir)/%_stemmer.py) \
 		 $(python_output_dir)/__init__.py
 JS_SOURCES = $(libstemmer_algorithms:%=$(js_output_dir)/%-stemmer.js) \
-	$(js_output_dir)/base-stemmer.js
+	$(js_output_dir)/base-stemmer.js \
+	$(libstemmer_algorithms:%=$(js_output_dir)/%-stemmer.esm.js) \
+	$(js_output_dir)/base-stemmer.esm.js
 RUST_SOURCES = $(libstemmer_algorithms:%=$(rust_src_dir)/%_stemmer.rs)
 GO_SOURCES = $(libstemmer_algorithms:%=$(go_src_dir)/%_stemmer.go) \
 	$(go_src_main_dir)/stemwords/algorithms.go
@@ -332,11 +334,20 @@ $(go_src_dir)/%_stemmer.go: algorithms/%.sbl snowball$(EXEEXT)
 
 $(js_output_dir)/%-stemmer.js: algorithms/%.sbl snowball$(EXEEXT)
 	@mkdir -p $(js_output_dir)
-	./snowball $< -js -o "$(js_output_dir)/$*-stemmer"
+	./snowball $< -js=global -o "$(js_output_dir)/$*-stemmer"
 
 $(js_output_dir)/base-stemmer.js: $(js_runtime_dir)/base-stemmer.js
 	@mkdir -p $(js_output_dir)
 	cp $< $@
+
+$(js_output_dir)/%-stemmer.esm.js: algorithms/%.sbl snowball$(EXEEXT)
+	@mkdir -p $(js_output_dir)
+	./snowball $< -js=esm -o "$(js_output_dir)/$*-stemmer"
+
+$(js_output_dir)/base-stemmer.esm.js: $(js_runtime_dir)/base-stemmer.js
+	@mkdir -p $(js_output_dir)
+	cp $< $@
+	echo "\nexport { BaseStemmer };" >> $@
 
 $(ada_src_dir)/stemmer-%.ads: algorithms/%.sbl snowball
 	@mkdir -p $(ada_src_dir)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -339,6 +339,7 @@ $(js_output_dir)/%-stemmer.js: algorithms/%.sbl snowball$(EXEEXT)
 $(js_output_dir)/base-stemmer.js: $(js_runtime_dir)/base-stemmer.js
 	@mkdir -p $(js_output_dir)
 	cp $< $@
+	echo "\nglobalThis.BaseStemmer = BaseStemmer;" >> $@
 
 $(js_output_dir)/%-stemmer.esm.js: algorithms/%.sbl snowball$(EXEEXT)
 	@mkdir -p $(js_output_dir)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -172,9 +172,7 @@ PASCAL_SOURCES = $(ISO_8859_1_algorithms:%=$(pascal_src_dir)/%Stemmer.pas)
 PYTHON_SOURCES = $(libstemmer_algorithms:%=$(python_output_dir)/%_stemmer.py) \
 		 $(python_output_dir)/__init__.py
 JS_SOURCES = $(libstemmer_algorithms:%=$(js_output_dir)/%-stemmer.js) \
-	$(js_output_dir)/base-stemmer.js \
-	$(libstemmer_algorithms:%=$(js_output_dir)/%-stemmer.esm.js) \
-	$(js_output_dir)/base-stemmer.esm.js
+	$(js_output_dir)/base-stemmer.js
 RUST_SOURCES = $(libstemmer_algorithms:%=$(rust_src_dir)/%_stemmer.rs)
 GO_SOURCES = $(libstemmer_algorithms:%=$(go_src_dir)/%_stemmer.go) \
 	$(go_src_main_dir)/stemwords/algorithms.go
@@ -345,21 +343,11 @@ $(go_src_dir)/%_stemmer.go: algorithms/%.sbl snowball$(EXEEXT)
 
 $(js_output_dir)/%-stemmer.js: algorithms/%.sbl snowball$(EXEEXT)
 	@mkdir -p $(js_output_dir)
-	./snowball $< -js=global -o "$(js_output_dir)/$*-stemmer"
+	./snowball $< -js -o "$(js_output_dir)/$*-stemmer"
 
 $(js_output_dir)/base-stemmer.js: $(js_runtime_dir)/base-stemmer.js
 	@mkdir -p $(js_output_dir)
 	cp $< $@
-	echo "\nglobalThis.BaseStemmer = BaseStemmer;" >> $@
-
-$(js_output_dir)/%-stemmer.esm.js: algorithms/%.sbl snowball$(EXEEXT)
-	@mkdir -p $(js_output_dir)
-	./snowball $< -js=esm -o "$(js_output_dir)/$*-stemmer"
-
-$(js_output_dir)/base-stemmer.esm.js: $(js_runtime_dir)/base-stemmer.js
-	@mkdir -p $(js_output_dir)
-	cp $< $@
-	echo "\nexport { BaseStemmer };" >> $@
 
 $(ada_src_dir)/stemmer-%.ads: algorithms/%.sbl snowball
 	@mkdir -p $(ada_src_dir)
@@ -685,21 +673,6 @@ check_js_%: $(STEMMING_DATA)/%
 	  rm tmp.in; \
 	else \
 	  $(JSRUN) javascript/stemwords.js -l $* -i $</voc.txt -o tmp.txt; \
-	fi
-	@if test -f '$</output.txt.gz' ; then \
-	  gzip -dc '$</output.txt.gz'|$(DIFF) -u - tmp.txt; \
-	else \
-	  $(DIFF) -u $</output.txt tmp.txt; \
-	fi
-	@rm tmp.txt
-
-	@echo "Checking output of $* stemmer for JS (ESM)"
-	@if test -f '$</voc.txt.gz' ; then \
-	  gzip -dc '$</voc.txt.gz' > tmp.in; \
-	  $(JSRUN) javascript/stemwords.js --esm -l $* -i tmp.in -o tmp.txt; \
-	  rm tmp.in; \
-	else \
-	  $(JSRUN) javascript/stemwords.js --esm -l $* -i $</voc.txt -o tmp.txt; \
 	fi
 	@if test -f '$</output.txt.gz' ; then \
 	  gzip -dc '$</output.txt.gz'|$(DIFF) -u - tmp.txt; \

--- a/compiler/driver.c
+++ b/compiler/driver.c
@@ -49,8 +49,7 @@ static void print_arglist(int exit_code) {
                "  -py, -python\n"
 #endif
 #ifndef DISABLE_JS
-               "  -js[=TYPE]                       generate Javascript (TYPE values:\n"
-               "                                   esm global, default: global)\n"
+               "  -js\n"
 #endif
 #ifndef DISABLE_RUST
                "  -rust\n"
@@ -115,7 +114,6 @@ static int read_options(struct options * o, int argc, char * argv[]) {
     o->output_file = NULL;
     o->syntax_tree = false;
     o->comments = false;
-    o->js_esm = false;
     o->externals_prefix = NULL;
     o->variables_prefix = NULL;
     o->runtime_path = NULL;
@@ -161,13 +159,8 @@ static int read_options(struct options * o, int argc, char * argv[]) {
                 continue;
             }
 #ifndef DISABLE_JS
-            if (eq(s, "-js") || eq(s, "-js=global")) {
+            if (eq(s, "-js")) {
                 o->make_lang = LANG_JAVASCRIPT;
-                o->js_esm = false;
-                continue;
-            } else if (eq(s, "-js=esm")) {
-                o->make_lang = LANG_JAVASCRIPT;
-                o->js_esm = true;
                 continue;
             }
 #endif
@@ -551,11 +544,7 @@ extern int main(int argc, char * argv[]) {
 #ifndef DISABLE_JS
                 if (o->make_lang == LANG_JAVASCRIPT) {
                     byte * s = add_sz_to_s(NULL, output_base);
-                    if (o->js_esm) {
-                        s = add_literal_to_s(s, ".esm.js");
-                    } else {
-                        s = add_literal_to_s(s, ".js");
-                    }
+                    s = add_literal_to_s(s, ".js");
                     o->output_src = get_output(s);
                     lose_s(s);
                     generate_program_js(g);

--- a/compiler/driver.c
+++ b/compiler/driver.c
@@ -49,7 +49,8 @@ static void print_arglist(int exit_code) {
                "  -py, -python\n"
 #endif
 #ifndef DISABLE_JS
-               "  -js                              generate Javascript\n"
+               "  -js[=TYPE]                       generate Javascript (TYPE values:\n"
+               "                                   esm global, default: global)\n"
 #endif
 #ifndef DISABLE_RUST
                "  -rust\n"
@@ -160,9 +161,13 @@ static int read_options(struct options * o, int argc, char * argv[]) {
                 continue;
             }
 #ifndef DISABLE_JS
-            if (eq(s, "-js")) {
+            if (eq(s, "-js") || eq(s, "-js=global")) {
                 o->make_lang = LANG_JAVASCRIPT;
                 o->js_esm = false;
+                continue;
+            } else if (eq(s, "-js=esm")) {
+                o->make_lang = LANG_JAVASCRIPT;
+                o->js_esm = true;
                 continue;
             }
 #endif
@@ -547,7 +552,7 @@ extern int main(int argc, char * argv[]) {
                 if (o->make_lang == LANG_JAVASCRIPT) {
                     byte * s = add_sz_to_s(NULL, output_base);
                     if (o->js_esm) {
-                        s = add_literal_to_s(s, ".mjs");
+                        s = add_literal_to_s(s, ".esm.js");
                     } else {
                         s = add_literal_to_s(s, ".js");
                     }

--- a/compiler/generator_js.c
+++ b/compiler/generator_js.c
@@ -226,19 +226,11 @@ static void writef(struct generator * g, const char * input, struct node * p) {
             case 'n': write_string(g, g->options->name); continue;
             case 'P': write_string(g, g->options->parent_class_name); continue;
             case 'C': { // Constant.
-                if (g->options->js_esm) {
-                    w(g, "const");
-                } else {
-                    w(g, "/** @const */ var");
-                }
+                w(g, "const");
                 continue;
             }
             case 'D': { // Declare variable.
-                if (g->options->js_esm) {
-                    w(g, "let");
-                } else {
-                    w(g, "var");
-                }
+                w(g, "let");
                 continue;
             }
             default:
@@ -1279,18 +1271,16 @@ static void generate(struct generator * g, struct node * p) {
 }
 
 static void generate_class_begin(struct generator * g) {
-    if (g->options->js_esm) {
-        w(g, "import { ~P } from './base-stemmer.esm.js'~N");
-        write_newline(g);
-    }
-    w(g, "/** @constructor */~N"
+    w(g, "import { ~P } from './base-stemmer.js'~N"
+         "~N"
+         "/** @constructor */~N"
          "~C ~n = function() {~+~N"
          "~M~C base = new ~P();~N");
     write_newline(g);
 }
 
 static void generate_class_end(struct generator * g) {
-    write_newline(g);
+    w(g, "~N");
     w(g, "~M/**@return{string}*/~N");
     w(g, "~Mthis['stemWord'] = function(/**string*/word) {~+~N");
     w(g, "~Mbase.setCurrent(word);~N");
@@ -1298,12 +1288,8 @@ static void generate_class_end(struct generator * g) {
     w(g, "~Mreturn base.getCurrent();~N");
     w(g, "~-~M};~N");
     w(g, "~-};~N");
-    write_newline(g);
-    if (g->options->js_esm) {
-        w(g, "export { ~n };~N");
-    } else {
-        w(g, "globalThis.~n = ~n;~N");
-    }
+    w(g, "~N");
+    w(g, "export { ~n };~N");
 }
 
 static void generate_among_table(struct generator * g, struct among * x) {

--- a/compiler/generator_js.c
+++ b/compiler/generator_js.c
@@ -1053,7 +1053,7 @@ static void generate_define(struct generator * g, struct node * p) {
     write_newline(g);
     write_comment(g, p);
 
-    if (g->options->js_esm || q->type == t_routine) {
+    if (q->type == t_routine) {
         writef(g, "~M/** @return {boolean} */~N"
                   "~Mfunction ~W() {~+~N", p);
     } else {
@@ -1278,39 +1278,29 @@ static void generate(struct generator * g, struct node * p) {
 
 static void generate_class_begin(struct generator * g) {
     if (g->options->js_esm) {
-        w(g, "import { ~P } from './base-stemmer.js'~N"
-             "/** @constructor */~N"
-             "~N"
-             "export const ~n = (() => {~+~N");
-    } else {
-        w(g, "/** @constructor */~N"
-             "var ~n = function() {~+~N");
+        w(g, "import { ~P } from './base-stemmer.esm.js'~N");
+        write_newline(g);
     }
-    w(g, "~M~C base = new ~P();~N");
+    w(g, "/** @constructor */~N"
+         "~C ~n = function() {~+~N"
+         "~M~C base = new ~P();~N");
     write_newline(g);
 }
 
 static void generate_class_end(struct generator * g) {
     write_newline(g);
+    w(g, "~M/**@return{string}*/~N");
+    w(g, "~Mthis['stemWord'] = function(/**string*/word) {~+~N");
+    w(g, "~Mbase.setCurrent(word);~N");
+    w(g, "~Mthis.stem();~N");
+    w(g, "~Mreturn base.getCurrent();~N");
+    w(g, "~-~M};~N");
+    w(g, "~-};~N");
+    write_newline(g);
     if (g->options->js_esm) {
-        // providing a name for the class is optional
-        w(g, "~Mreturn class ~n {~+~N");
-        w(g, "~M/** @return{string} */~N");
-        w(g, "~MstemWord(/** string */word) {~+~N");
-        w(g, "~Mbase.setCurrent(word);~N");
-        w(g, "~Mstem();~N");
-        w(g, "~Mreturn base.getCurrent();~N");
-        w(g, "~-~M};~N");
-        w(g, "~-~M};~N");
-        w(g, "~-})();~N");
+        w(g, "export { ~n };~N");
     } else {
-        w(g, "~M/** @return{string} */~N");
-        w(g, "~Mthis['stemWord'] = function(/** string */word) {~+~N");
-        w(g, "~Mbase.setCurrent(word);~N");
-        w(g, "~Mthis.stem();~N");
-        w(g, "~Mreturn base.getCurrent();~N");
-        w(g, "~-~M};~N");
-        w(g, "~-};~N");
+        w(g, "globalThis.~n = ~n;~N");
     }
 }
 

--- a/compiler/generator_js.c
+++ b/compiler/generator_js.c
@@ -218,11 +218,19 @@ static void writef(struct generator * g, const char * input, struct node * p) {
             case 'n': write_string(g, g->options->name); continue;
             case 'P': write_string(g, g->options->parent_class_name); continue;
             case 'C': { // Constant.
-                w(g, "const");
+                if (g->options->js_esm) {
+                    w(g, "const");
+                } else {
+                    w(g, "/** @const */ var");
+                }
                 continue;
             }
             case 'D': { // Declare variable.
-                w(g, "let");
+                if (g->options->js_esm) {
+                    w(g, "let");
+                } else {
+                    w(g, "var");
+                }
                 continue;
             }
             default:

--- a/compiler/header.h
+++ b/compiler/header.h
@@ -388,7 +388,6 @@ struct options {
     FILE * output_h;
     byte syntax_tree;
     byte comments;
-    byte js_esm;
     enc encoding;
     enum { LANG_JAVA, LANG_C, LANG_CPLUSPLUS, LANG_CSHARP, LANG_PASCAL, LANG_PYTHON, LANG_JAVASCRIPT, LANG_RUST, LANG_GO, LANG_ADA } make_lang;
     const char * externals_prefix;

--- a/compiler/header.h
+++ b/compiler/header.h
@@ -1,5 +1,4 @@
 #include <stdio.h>
-#include <stdbool.h>  // bool
 
 #define SNOWBALL_VERSION "3.0.0"
 

--- a/compiler/header.h
+++ b/compiler/header.h
@@ -386,7 +386,7 @@ struct options {
     FILE * output_h;
     byte syntax_tree;
     byte comments;
-    bool js_esm;
+    byte js_esm;
     enc encoding;
     enum { LANG_JAVA, LANG_C, LANG_CPLUSPLUS, LANG_CSHARP, LANG_PASCAL, LANG_PYTHON, LANG_JAVASCRIPT, LANG_RUST, LANG_GO, LANG_ADA } make_lang;
     const char * externals_prefix;

--- a/compiler/header.h
+++ b/compiler/header.h
@@ -5,6 +5,9 @@
 typedef unsigned char byte;
 typedef unsigned short symbol;
 
+#define true 1
+#define false 0
+
 #define MALLOC check_malloc
 #define FREE check_free
 

--- a/compiler/header.h
+++ b/compiler/header.h
@@ -1,12 +1,10 @@
 #include <stdio.h>
+#include <stdbool.h>  // bool
 
 #define SNOWBALL_VERSION "3.0.0"
 
 typedef unsigned char byte;
 typedef unsigned short symbol;
-
-#define true 1
-#define false 0
 
 #define MALLOC check_malloc
 #define FREE check_free
@@ -388,7 +386,7 @@ struct options {
     FILE * output_h;
     byte syntax_tree;
     byte comments;
-    byte js_esm;
+    bool js_esm;
     enc encoding;
     enum { LANG_JAVA, LANG_C, LANG_CPLUSPLUS, LANG_CSHARP, LANG_PASCAL, LANG_PYTHON, LANG_JAVASCRIPT, LANG_RUST, LANG_GO, LANG_ADA } make_lang;
     const char * externals_prefix;

--- a/javascript/base-stemmer.js
+++ b/javascript/base-stemmer.js
@@ -465,3 +465,5 @@ const BaseStemmer = function() {
         return result;
     };
 };
+
+export { BaseStemmer };

--- a/javascript/base-stemmer.js
+++ b/javascript/base-stemmer.js
@@ -1,38 +1,39 @@
 // @ts-check
 
-/**@constructor*/
-const BaseStemmer = function() {
-    /** @protected */
-    this.current = '';
-    this.cursor = 0;
-    this.limit = 0;
-    this.limit_backward = 0;
-    this.bra = 0;
-    this.ket = 0;
+class BaseStemmer {
+    constructor() {
+        /** @protected */
+        this.current = '';
+        this.cursor = 0;
+        this.limit = 0;
+        this.limit_backward = 0;
+        this.bra = 0;
+        this.ket = 0;
+    }
 
     /**
      * @param {string} value
      */
-    this.setCurrent = function(value) {
+    setCurrent(value) {
         this.current = value;
         this.cursor = 0;
         this.limit = this.current.length;
         this.limit_backward = 0;
         this.bra = this.cursor;
         this.ket = this.limit;
-    };
+    }
 
     /**
      * @return {string}
      */
-    this.getCurrent = function() {
+    getCurrent() {
         return this.current;
-    };
+    }
 
     /**
      * @param {BaseStemmer} other
      */
-    this.copy_from = function(other) {
+    copy_from(other) {
         /** @protected */
         this.current          = other.current;
         this.cursor           = other.cursor;
@@ -40,7 +41,7 @@ const BaseStemmer = function() {
         this.limit_backward   = other.limit_backward;
         this.bra              = other.bra;
         this.ket              = other.ket;
-    };
+    }
 
     /**
      * @param {number[]} s
@@ -48,16 +49,16 @@ const BaseStemmer = function() {
      * @param {number} max
      * @return {boolean}
      */
-    this.in_grouping = function(s, min, max) {
+    in_grouping(s, min, max) {
         /** @protected */
         if (this.cursor >= this.limit) return false;
-        var ch = this.current.charCodeAt(this.cursor);
+        let ch = this.current.charCodeAt(this.cursor);
         if (ch > max || ch < min) return false;
         ch -= min;
-        if ((s[ch >>> 3] & (0x1 << (ch & 0x7))) == 0) return false;
+        if ((s[ch >>> 3] & (0x1 << (ch & 0x7))) === 0) return false;
         this.cursor++;
         return true;
-    };
+    }
 
     /**
      * @param {number[]} s
@@ -65,19 +66,19 @@ const BaseStemmer = function() {
      * @param {number} max
      * @return {boolean}
      */
-    this.go_in_grouping = function(s, min, max) {
+    go_in_grouping(s, min, max) {
         /** @protected */
         while (this.cursor < this.limit) {
-            var ch = this.current.charCodeAt(this.cursor);
+            let ch = this.current.charCodeAt(this.cursor);
             if (ch > max || ch < min)
                 return true;
             ch -= min;
-            if ((s[ch >>> 3] & (0x1 << (ch & 0x7))) == 0)
+            if ((s[ch >>> 3] & (0x1 << (ch & 0x7))) === 0)
                 return true;
             this.cursor++;
         }
         return false;
-    };
+    }
 
     /**
      * @param {number[]} s
@@ -85,16 +86,16 @@ const BaseStemmer = function() {
      * @param {number} max
      * @return {boolean}
      */
-    this.in_grouping_b = function(s, min, max) {
+    in_grouping_b(s, min, max) {
         /** @protected */
         if (this.cursor <= this.limit_backward) return false;
-        var ch = this.current.charCodeAt(this.cursor - 1);
+        let ch = this.current.charCodeAt(this.cursor - 1);
         if (ch > max || ch < min) return false;
         ch -= min;
-        if ((s[ch >>> 3] & (0x1 << (ch & 0x7))) == 0) return false;
+        if ((s[ch >>> 3] & (0x1 << (ch & 0x7))) === 0) return false;
         this.cursor--;
         return true;
-    };
+    }
 
     /**
      * @param {number[]} s
@@ -102,17 +103,17 @@ const BaseStemmer = function() {
      * @param {number} max
      * @return {boolean}
      */
-    this.go_in_grouping_b = function(s, min, max) {
+    go_in_grouping_b(s, min, max) {
         /** @protected */
         while (this.cursor > this.limit_backward) {
-            var ch = this.current.charCodeAt(this.cursor - 1);
+            let ch = this.current.charCodeAt(this.cursor - 1);
             if (ch > max || ch < min) return true;
             ch -= min;
-            if ((s[ch >>> 3] & (0x1 << (ch & 0x7))) == 0) return true;
+            if ((s[ch >>> 3] & (0x1 << (ch & 0x7))) === 0) return true;
             this.cursor--;
         }
         return false;
-    };
+    }
 
     /**
      * @param {number[]} s
@@ -120,21 +121,21 @@ const BaseStemmer = function() {
      * @param {number} max
      * @return {boolean}
      */
-    this.out_grouping = function(s, min, max) {
+    out_grouping(s, min, max) {
         /** @protected */
         if (this.cursor >= this.limit) return false;
-        var ch = this.current.charCodeAt(this.cursor);
+        let ch = this.current.charCodeAt(this.cursor);
         if (ch > max || ch < min) {
             this.cursor++;
             return true;
         }
         ch -= min;
-        if ((s[ch >>> 3] & (0X1 << (ch & 0x7))) == 0) {
+        if ((s[ch >>> 3] & (0X1 << (ch & 0x7))) === 0) {
             this.cursor++;
             return true;
         }
         return false;
-    };
+    }
 
     /**
      * @param {number[]} s
@@ -142,20 +143,20 @@ const BaseStemmer = function() {
      * @param {number} max
      * @return {boolean}
      */
-    this.go_out_grouping = function(s, min, max) {
+    go_out_grouping(s, min, max) {
         /** @protected */
         while (this.cursor < this.limit) {
-            var ch = this.current.charCodeAt(this.cursor);
+            let ch = this.current.charCodeAt(this.cursor);
             if (ch <= max && ch >= min) {
                 ch -= min;
-                if ((s[ch >>> 3] & (0X1 << (ch & 0x7))) != 0) {
+                if ((s[ch >>> 3] & (0X1 << (ch & 0x7))) !== 0) {
                     return true;
                 }
             }
             this.cursor++;
         }
         return false;
-    };
+    }
 
     /**
      * @param {number[]} s
@@ -163,21 +164,21 @@ const BaseStemmer = function() {
      * @param {number} max
      * @return {boolean}
      */
-    this.out_grouping_b = function(s, min, max) {
+    out_grouping_b(s, min, max) {
         /** @protected */
         if (this.cursor <= this.limit_backward) return false;
-        var ch = this.current.charCodeAt(this.cursor - 1);
+        let ch = this.current.charCodeAt(this.cursor - 1);
         if (ch > max || ch < min) {
             this.cursor--;
             return true;
         }
         ch -= min;
-        if ((s[ch >>> 3] & (0x1 << (ch & 0x7))) == 0) {
+        if ((s[ch >>> 3] & (0x1 << (ch & 0x7))) === 0) {
             this.cursor--;
             return true;
         }
         return false;
-    };
+    }
 
     /**
      * @param {number[]} s
@@ -185,88 +186,88 @@ const BaseStemmer = function() {
      * @param {number} max
      * @return {boolean}
      */
-    this.go_out_grouping_b = function(s, min, max) {
+    go_out_grouping_b(s, min, max) {
         /** @protected */
         while (this.cursor > this.limit_backward) {
-            var ch = this.current.charCodeAt(this.cursor - 1);
+            let ch = this.current.charCodeAt(this.cursor - 1);
             if (ch <= max && ch >= min) {
                 ch -= min;
-                if ((s[ch >>> 3] & (0x1 << (ch & 0x7))) != 0) {
+                if ((s[ch >>> 3] & (0x1 << (ch & 0x7))) !== 0) {
                     return true;
                 }
             }
             this.cursor--;
         }
         return false;
-    };
+    }
 
     /**
      * @param {string} s
      * @return {boolean}
      */
-    this.eq_s = function(s)
+    eq_s(s)
     {
         /** @protected */
         if (this.limit - this.cursor < s.length) return false;
-        if (this.current.slice(this.cursor, this.cursor + s.length) != s)
+        if (this.current.slice(this.cursor, this.cursor + s.length) !== s)
         {
             return false;
         }
         this.cursor += s.length;
         return true;
-    };
+    }
 
     /**
      * @param {string} s
      * @return {boolean}
      */
-    this.eq_s_b = function(s)
+    eq_s_b(s)
     {
         /** @protected */
         if (this.cursor - this.limit_backward < s.length) return false;
-        if (this.current.slice(this.cursor - s.length, this.cursor) != s)
+        if (this.current.slice(this.cursor - s.length, this.cursor) !== s)
         {
             return false;
         }
         this.cursor -= s.length;
         return true;
-    };
+    }
 
     /**
      * @param {Among[]} v
      * @return {number}
      */
-    this.find_among = function(v)
+    find_among(v)
     {
         /** @protected */
-        var i = 0;
-        var j = v.length;
+        let i = 0;
+        let j = v.length;
 
-        var c = this.cursor;
-        var l = this.limit;
+        let c = this.cursor;
+        let l = this.limit;
 
-        var common_i = 0;
-        var common_j = 0;
+        let common_i = 0;
+        let common_j = 0;
 
-        var first_key_inspected = false;
+        let first_key_inspected = false;
 
         while (true)
         {
-            var k = i + ((j - i) >>> 1);
-            var diff = 0;
-            var common = common_i < common_j ? common_i : common_j; // smaller
+            let k = i + ((j - i) >>> 1);
+            let diff = 0;
+            let common = common_i < common_j ? common_i : common_j; // smaller
             // w[0]: string, w[1]: substring_i, w[2]: result, w[3]: function (optional)
-            var w = v[k];
-            var i2;
+            let w = v[k];
+            let i2;
             for (i2 = common; i2 < w[0].length; i2++)
             {
-                if (c + common == l)
+                if (c + common === l)
                 {
                     diff = -1;
                     break;
                 }
                 diff = this.current.charCodeAt(c + common) - w[0].charCodeAt(i2);
-                if (diff != 0) break;
+                if (diff !== 0) break;
                 common++;
             }
             if (diff < 0)
@@ -282,7 +283,7 @@ const BaseStemmer = function() {
             if (j - i <= 1)
             {
                 if (i > 0) break; // v->s has been inspected
-                if (j == i) break; // only one item in v
+                if (j === i) break; // only one item in v
 
                 // - but now we need to go round once more to get
                 // v->s inspected. This looks messy, but is actually
@@ -293,55 +294,55 @@ const BaseStemmer = function() {
             }
         }
         do {
-            var w = v[i];
+            let w = v[i];
             if (common_i >= w[0].length)
             {
                 this.cursor = c + w[0].length;
                 if (w.length < 4) return w[2];
-                var res = w[3](this);
+                let res = w[3](this);
                 this.cursor = c + w[0].length;
                 if (res) return w[2];
             }
             i = w[1];
         } while (i >= 0);
         return 0;
-    };
+    }
 
     // find_among_b is for backwards processing. Same comments apply
     /**
      * @param {Among[]} v
      * @return {number}
      */
-    this.find_among_b = function(v)
+    find_among_b(v)
     {
         /** @protected */
-        var i = 0;
-        var j = v.length
+        let i = 0;
+        let j = v.length
 
-        var c = this.cursor;
-        var lb = this.limit_backward;
+        let c = this.cursor;
+        let lb = this.limit_backward;
 
-        var common_i = 0;
-        var common_j = 0;
+        let common_i = 0;
+        let common_j = 0;
 
-        var first_key_inspected = false;
+        let first_key_inspected = false;
 
         while (true)
         {
-            var k = i + ((j - i) >> 1);
-            var diff = 0;
-            var common = common_i < common_j ? common_i : common_j;
-            var w = v[k];
-            var i2;
+            let k = i + ((j - i) >> 1);
+            let diff = 0;
+            let common = common_i < common_j ? common_i : common_j;
+            let w = v[k];
+            let i2;
             for (i2 = w[0].length - 1 - common; i2 >= 0; i2--)
             {
-                if (c - common == lb)
+                if (c - common === lb)
                 {
                     diff = -1;
                     break;
                 }
                 diff = this.current.charCodeAt(c - 1 - common) - w[0].charCodeAt(i2);
-                if (diff != 0) break;
+                if (diff !== 0) break;
                 common++;
             }
             if (diff < 0)
@@ -357,25 +358,25 @@ const BaseStemmer = function() {
             if (j - i <= 1)
             {
                 if (i > 0) break;
-                if (j == i) break;
+                if (j === i) break;
                 if (first_key_inspected) break;
                 first_key_inspected = true;
             }
         }
         do {
-            var w = v[i];
+            let w = v[i];
             if (common_i >= w[0].length)
             {
                 this.cursor = c - w[0].length;
                 if (w.length < 4) return w[2];
-                var res = w[3](this);
+                let res = w[3](this);
                 this.cursor = c - w[0].length;
                 if (res) return w[2];
             }
             i = w[1];
         } while (i >= 0);
         return 0;
-    };
+    }
 
     /* to replace chars between c_bra and c_ket in this.current by the
      * chars in s.
@@ -386,21 +387,21 @@ const BaseStemmer = function() {
      * @param {string} s
      * @return {number}
      */
-    this.replace_s = function(c_bra, c_ket, s)
+    replace_s(c_bra, c_ket, s)
     {
         /** @protected */
-        var adjustment = s.length - (c_ket - c_bra);
+        let adjustment = s.length - (c_ket - c_bra);
         this.current = this.current.slice(0, c_bra) + s + this.current.slice(c_ket);
         this.limit += adjustment;
         if (this.cursor >= c_ket) this.cursor += adjustment;
         else if (this.cursor > c_bra) this.cursor = c_bra;
         return adjustment;
-    };
+    }
 
     /**
      * @return {boolean}
      */
-    this.slice_check = function()
+    slice_check()
     {
         /** @protected */
         if (this.bra < 0 ||
@@ -411,59 +412,57 @@ const BaseStemmer = function() {
             return false;
         }
         return true;
-    };
+    }
 
     /**
      * @param {string} s
      * @return {boolean}
      */
-    this.slice_from = function(s)
+    slice_from(s)
     {
         /** @protected */
-        var result = false;
+        let result = false;
         if (this.slice_check())
         {
             this.replace_s(this.bra, this.ket, s);
             result = true;
         }
         return result;
-    };
+    }
 
     /**
      * @return {boolean}
      */
-    this.slice_del = function()
+    slice_del()
     {
         /** @protected */
         return this.slice_from("");
-    };
+    }
 
     /**
      * @param {number} c_bra
      * @param {number} c_ket
      * @param {string} s
      */
-    this.insert = function(c_bra, c_ket, s)
+    insert(c_bra, c_ket, s)
     {
         /** @protected */
-        var adjustment = this.replace_s(c_bra, c_ket, s);
+        let adjustment = this.replace_s(c_bra, c_ket, s);
         if (c_bra <= this.bra) this.bra += adjustment;
         if (c_bra <= this.ket) this.ket += adjustment;
-    };
+    }
 
     /**
      * @return {string}
      */
-    this.slice_to = function()
+    slice_to()
     {
         /** @protected */
-        var result = '';
+        let result = '';
         if (this.slice_check())
         {
             result = this.current.slice(this.bra, this.ket);
         }
         return result;
-    };
-};
-
-if (typeof module === 'object' && module.exports) module.exports = BaseStemmer;
+    }
+}

--- a/javascript/base-stemmer.js
+++ b/javascript/base-stemmer.js
@@ -1,39 +1,38 @@
 // @ts-check
 
-class BaseStemmer {
-    constructor() {
-        /** @protected */
-        this.current = '';
-        this.cursor = 0;
-        this.limit = 0;
-        this.limit_backward = 0;
-        this.bra = 0;
-        this.ket = 0;
-    }
+/**@constructor*/
+const BaseStemmer = function() {
+    /** @protected */
+    this.current = '';
+    this.cursor = 0;
+    this.limit = 0;
+    this.limit_backward = 0;
+    this.bra = 0;
+    this.ket = 0;
 
     /**
      * @param {string} value
      */
-    setCurrent(value) {
+    this.setCurrent = function(value) {
         this.current = value;
         this.cursor = 0;
         this.limit = this.current.length;
         this.limit_backward = 0;
         this.bra = this.cursor;
         this.ket = this.limit;
-    }
+    };
 
     /**
      * @return {string}
      */
-    getCurrent() {
+    this.getCurrent = function() {
         return this.current;
-    }
+    };
 
     /**
      * @param {BaseStemmer} other
      */
-    copy_from(other) {
+    this.copy_from = function(other) {
         /** @protected */
         this.current          = other.current;
         this.cursor           = other.cursor;
@@ -41,7 +40,7 @@ class BaseStemmer {
         this.limit_backward   = other.limit_backward;
         this.bra              = other.bra;
         this.ket              = other.ket;
-    }
+    };
 
     /**
      * @param {number[]} s
@@ -49,16 +48,16 @@ class BaseStemmer {
      * @param {number} max
      * @return {boolean}
      */
-    in_grouping(s, min, max) {
+    this.in_grouping = function(s, min, max) {
         /** @protected */
         if (this.cursor >= this.limit) return false;
-        let ch = this.current.charCodeAt(this.cursor);
+        var ch = this.current.charCodeAt(this.cursor);
         if (ch > max || ch < min) return false;
         ch -= min;
-        if ((s[ch >>> 3] & (0x1 << (ch & 0x7))) === 0) return false;
+        if ((s[ch >>> 3] & (0x1 << (ch & 0x7))) == 0) return false;
         this.cursor++;
         return true;
-    }
+    };
 
     /**
      * @param {number[]} s
@@ -66,19 +65,19 @@ class BaseStemmer {
      * @param {number} max
      * @return {boolean}
      */
-    go_in_grouping(s, min, max) {
+    this.go_in_grouping = function(s, min, max) {
         /** @protected */
         while (this.cursor < this.limit) {
-            let ch = this.current.charCodeAt(this.cursor);
+            var ch = this.current.charCodeAt(this.cursor);
             if (ch > max || ch < min)
                 return true;
             ch -= min;
-            if ((s[ch >>> 3] & (0x1 << (ch & 0x7))) === 0)
+            if ((s[ch >>> 3] & (0x1 << (ch & 0x7))) == 0)
                 return true;
             this.cursor++;
         }
         return false;
-    }
+    };
 
     /**
      * @param {number[]} s
@@ -86,16 +85,16 @@ class BaseStemmer {
      * @param {number} max
      * @return {boolean}
      */
-    in_grouping_b(s, min, max) {
+    this.in_grouping_b = function(s, min, max) {
         /** @protected */
         if (this.cursor <= this.limit_backward) return false;
-        let ch = this.current.charCodeAt(this.cursor - 1);
+        var ch = this.current.charCodeAt(this.cursor - 1);
         if (ch > max || ch < min) return false;
         ch -= min;
-        if ((s[ch >>> 3] & (0x1 << (ch & 0x7))) === 0) return false;
+        if ((s[ch >>> 3] & (0x1 << (ch & 0x7))) == 0) return false;
         this.cursor--;
         return true;
-    }
+    };
 
     /**
      * @param {number[]} s
@@ -103,17 +102,17 @@ class BaseStemmer {
      * @param {number} max
      * @return {boolean}
      */
-    go_in_grouping_b(s, min, max) {
+    this.go_in_grouping_b = function(s, min, max) {
         /** @protected */
         while (this.cursor > this.limit_backward) {
-            let ch = this.current.charCodeAt(this.cursor - 1);
+            var ch = this.current.charCodeAt(this.cursor - 1);
             if (ch > max || ch < min) return true;
             ch -= min;
-            if ((s[ch >>> 3] & (0x1 << (ch & 0x7))) === 0) return true;
+            if ((s[ch >>> 3] & (0x1 << (ch & 0x7))) == 0) return true;
             this.cursor--;
         }
         return false;
-    }
+    };
 
     /**
      * @param {number[]} s
@@ -121,21 +120,21 @@ class BaseStemmer {
      * @param {number} max
      * @return {boolean}
      */
-    out_grouping(s, min, max) {
+    this.out_grouping = function(s, min, max) {
         /** @protected */
         if (this.cursor >= this.limit) return false;
-        let ch = this.current.charCodeAt(this.cursor);
+        var ch = this.current.charCodeAt(this.cursor);
         if (ch > max || ch < min) {
             this.cursor++;
             return true;
         }
         ch -= min;
-        if ((s[ch >>> 3] & (0X1 << (ch & 0x7))) === 0) {
+        if ((s[ch >>> 3] & (0X1 << (ch & 0x7))) == 0) {
             this.cursor++;
             return true;
         }
         return false;
-    }
+    };
 
     /**
      * @param {number[]} s
@@ -143,20 +142,20 @@ class BaseStemmer {
      * @param {number} max
      * @return {boolean}
      */
-    go_out_grouping(s, min, max) {
+    this.go_out_grouping = function(s, min, max) {
         /** @protected */
         while (this.cursor < this.limit) {
-            let ch = this.current.charCodeAt(this.cursor);
+            var ch = this.current.charCodeAt(this.cursor);
             if (ch <= max && ch >= min) {
                 ch -= min;
-                if ((s[ch >>> 3] & (0X1 << (ch & 0x7))) !== 0) {
+                if ((s[ch >>> 3] & (0X1 << (ch & 0x7))) != 0) {
                     return true;
                 }
             }
             this.cursor++;
         }
         return false;
-    }
+    };
 
     /**
      * @param {number[]} s
@@ -164,21 +163,21 @@ class BaseStemmer {
      * @param {number} max
      * @return {boolean}
      */
-    out_grouping_b(s, min, max) {
+    this.out_grouping_b = function(s, min, max) {
         /** @protected */
         if (this.cursor <= this.limit_backward) return false;
-        let ch = this.current.charCodeAt(this.cursor - 1);
+        var ch = this.current.charCodeAt(this.cursor - 1);
         if (ch > max || ch < min) {
             this.cursor--;
             return true;
         }
         ch -= min;
-        if ((s[ch >>> 3] & (0x1 << (ch & 0x7))) === 0) {
+        if ((s[ch >>> 3] & (0x1 << (ch & 0x7))) == 0) {
             this.cursor--;
             return true;
         }
         return false;
-    }
+    };
 
     /**
      * @param {number[]} s
@@ -186,88 +185,88 @@ class BaseStemmer {
      * @param {number} max
      * @return {boolean}
      */
-    go_out_grouping_b(s, min, max) {
+    this.go_out_grouping_b = function(s, min, max) {
         /** @protected */
         while (this.cursor > this.limit_backward) {
-            let ch = this.current.charCodeAt(this.cursor - 1);
+            var ch = this.current.charCodeAt(this.cursor - 1);
             if (ch <= max && ch >= min) {
                 ch -= min;
-                if ((s[ch >>> 3] & (0x1 << (ch & 0x7))) !== 0) {
+                if ((s[ch >>> 3] & (0x1 << (ch & 0x7))) != 0) {
                     return true;
                 }
             }
             this.cursor--;
         }
         return false;
-    }
+    };
 
     /**
      * @param {string} s
      * @return {boolean}
      */
-    eq_s(s)
+    this.eq_s = function(s)
     {
         /** @protected */
         if (this.limit - this.cursor < s.length) return false;
-        if (this.current.slice(this.cursor, this.cursor + s.length) !== s)
+        if (this.current.slice(this.cursor, this.cursor + s.length) != s)
         {
             return false;
         }
         this.cursor += s.length;
         return true;
-    }
+    };
 
     /**
      * @param {string} s
      * @return {boolean}
      */
-    eq_s_b(s)
+    this.eq_s_b = function(s)
     {
         /** @protected */
         if (this.cursor - this.limit_backward < s.length) return false;
-        if (this.current.slice(this.cursor - s.length, this.cursor) !== s)
+        if (this.current.slice(this.cursor - s.length, this.cursor) != s)
         {
             return false;
         }
         this.cursor -= s.length;
         return true;
-    }
+    };
 
     /**
      * @param {Among[]} v
      * @return {number}
      */
-    find_among(v)
+    this.find_among = function(v)
     {
         /** @protected */
-        let i = 0;
-        let j = v.length;
+        var i = 0;
+        var j = v.length;
 
-        let c = this.cursor;
-        let l = this.limit;
+        var c = this.cursor;
+        var l = this.limit;
 
-        let common_i = 0;
-        let common_j = 0;
+        var common_i = 0;
+        var common_j = 0;
 
-        let first_key_inspected = false;
+        var first_key_inspected = false;
 
         while (true)
         {
-            let k = i + ((j - i) >>> 1);
-            let diff = 0;
-            let common = common_i < common_j ? common_i : common_j; // smaller
+            var k = i + ((j - i) >>> 1);
+            var diff = 0;
+            var common = common_i < common_j ? common_i : common_j; // smaller
             // w[0]: string, w[1]: substring_i, w[2]: result, w[3]: function (optional)
-            let w = v[k];
-            let i2;
+            var w = v[k];
+            var i2;
             for (i2 = common; i2 < w[0].length; i2++)
             {
-                if (c + common === l)
+                if (c + common == l)
                 {
                     diff = -1;
                     break;
                 }
                 diff = this.current.charCodeAt(c + common) - w[0].charCodeAt(i2);
-                if (diff !== 0) break;
+                if (diff != 0) break;
                 common++;
             }
             if (diff < 0)
@@ -283,7 +282,7 @@ class BaseStemmer {
             if (j - i <= 1)
             {
                 if (i > 0) break; // v->s has been inspected
-                if (j === i) break; // only one item in v
+                if (j == i) break; // only one item in v
 
                 // - but now we need to go round once more to get
                 // v->s inspected. This looks messy, but is actually
@@ -294,55 +293,55 @@ class BaseStemmer {
             }
         }
         do {
-            let w = v[i];
+            var w = v[i];
             if (common_i >= w[0].length)
             {
                 this.cursor = c + w[0].length;
                 if (w.length < 4) return w[2];
-                let res = w[3](this);
+                var res = w[3](this);
                 this.cursor = c + w[0].length;
                 if (res) return w[2];
             }
             i = w[1];
         } while (i >= 0);
         return 0;
-    }
+    };
 
     // find_among_b is for backwards processing. Same comments apply
     /**
      * @param {Among[]} v
      * @return {number}
      */
-    find_among_b(v)
+    this.find_among_b = function(v)
     {
         /** @protected */
-        let i = 0;
-        let j = v.length
+        var i = 0;
+        var j = v.length
 
-        let c = this.cursor;
-        let lb = this.limit_backward;
+        var c = this.cursor;
+        var lb = this.limit_backward;
 
-        let common_i = 0;
-        let common_j = 0;
+        var common_i = 0;
+        var common_j = 0;
 
-        let first_key_inspected = false;
+        var first_key_inspected = false;
 
         while (true)
         {
-            let k = i + ((j - i) >> 1);
-            let diff = 0;
-            let common = common_i < common_j ? common_i : common_j;
-            let w = v[k];
-            let i2;
+            var k = i + ((j - i) >> 1);
+            var diff = 0;
+            var common = common_i < common_j ? common_i : common_j;
+            var w = v[k];
+            var i2;
             for (i2 = w[0].length - 1 - common; i2 >= 0; i2--)
             {
-                if (c - common === lb)
+                if (c - common == lb)
                 {
                     diff = -1;
                     break;
                 }
                 diff = this.current.charCodeAt(c - 1 - common) - w[0].charCodeAt(i2);
-                if (diff !== 0) break;
+                if (diff != 0) break;
                 common++;
             }
             if (diff < 0)
@@ -358,25 +357,25 @@ class BaseStemmer {
             if (j - i <= 1)
             {
                 if (i > 0) break;
-                if (j === i) break;
+                if (j == i) break;
                 if (first_key_inspected) break;
                 first_key_inspected = true;
             }
         }
         do {
-            let w = v[i];
+            var w = v[i];
             if (common_i >= w[0].length)
             {
                 this.cursor = c - w[0].length;
                 if (w.length < 4) return w[2];
-                let res = w[3](this);
+                var res = w[3](this);
                 this.cursor = c - w[0].length;
                 if (res) return w[2];
             }
             i = w[1];
         } while (i >= 0);
         return 0;
-    }
+    };
 
     /* to replace chars between c_bra and c_ket in this.current by the
      * chars in s.
@@ -387,21 +386,21 @@ class BaseStemmer {
      * @param {string} s
      * @return {number}
      */
-    replace_s(c_bra, c_ket, s)
+    this.replace_s = function(c_bra, c_ket, s)
     {
         /** @protected */
-        let adjustment = s.length - (c_ket - c_bra);
+        var adjustment = s.length - (c_ket - c_bra);
         this.current = this.current.slice(0, c_bra) + s + this.current.slice(c_ket);
         this.limit += adjustment;
         if (this.cursor >= c_ket) this.cursor += adjustment;
         else if (this.cursor > c_bra) this.cursor = c_bra;
         return adjustment;
-    }
+    };
 
     /**
      * @return {boolean}
      */
-    slice_check()
+    this.slice_check = function()
     {
         /** @protected */
         if (this.bra < 0 ||
@@ -412,57 +411,57 @@ class BaseStemmer {
             return false;
         }
         return true;
-    }
+    };
 
     /**
      * @param {string} s
      * @return {boolean}
      */
-    slice_from(s)
+    this.slice_from = function(s)
     {
         /** @protected */
-        let result = false;
+        var result = false;
         if (this.slice_check())
         {
             this.replace_s(this.bra, this.ket, s);
             result = true;
         }
         return result;
-    }
+    };
 
     /**
      * @return {boolean}
      */
-    slice_del()
+    this.slice_del = function()
     {
         /** @protected */
         return this.slice_from("");
-    }
+    };
 
     /**
      * @param {number} c_bra
      * @param {number} c_ket
      * @param {string} s
      */
-    insert(c_bra, c_ket, s)
+    this.insert = function(c_bra, c_ket, s)
     {
         /** @protected */
-        let adjustment = this.replace_s(c_bra, c_ket, s);
+        var adjustment = this.replace_s(c_bra, c_ket, s);
         if (c_bra <= this.bra) this.bra += adjustment;
         if (c_bra <= this.ket) this.ket += adjustment;
-    }
+    };
 
     /**
      * @return {string}
      */
-    slice_to()
+    this.slice_to = function()
     {
         /** @protected */
-        let result = '';
+        var result = '';
         if (this.slice_check())
         {
             result = this.current.slice(this.bra, this.ket);
         }
         return result;
-    }
-}
+    };
+};

--- a/javascript/stemwords.js
+++ b/javascript/stemwords.js
@@ -2,13 +2,12 @@ const fs = require('fs');
 const readline = require('readline');
 
 function usage() {
-    console.log("usage: stemwords.js [-l <language>] -i <input file> -o <output file> [-c <character encoding>] [--esm] [-h]\n");
+    console.log("usage: stemwords.js [-l <language>] -i <input file> -o <output file> [-c <character encoding>] [-h]\n");
     console.log("The input file consists of a list of words to be stemmed, one per");
     console.log("line. Words should be in lower case.\n");
     console.log("If -c is given, the argument is the character encoding of the input");
     console.log("and output files.  If it is omitted, the UTF-8 encoding is used.\n");
     console.log("The output file consists of the stemmed words, one per line.\n");
-    console.log("Using --esm loads JavaScript Modules (ESM).\n");
     console.log("-h displays this help");
 }
 
@@ -23,7 +22,6 @@ else
     var encoding = 'utf8';
     var language = 'English';
     var show_help = false;
-    let use_esm = false;
     while (process.argv.length > 0)
     {
         var arg = process.argv.shift();
@@ -65,9 +63,6 @@ else
             }
             encoding = process.argv.shift();
             break;
-        case "--esm":
-            use_esm = true;
-            break;
         }
     }
     if (show_help || input === '' || output === '')
@@ -76,30 +71,24 @@ else
     }
     else
     {
-        stemming(language, input, output, encoding, use_esm);
+        stemming(language, input, output, encoding);
     }
 }
 
-// function stemming (lang : string, input : string, output : string, encoding : string, use_esm : Boolean) {
-function stemming(lang, input, output, encoding, use_esm) {
-    if (!use_esm) {
-        // Load BaseStemmer into the global scope
-        require('base-stemmer.js');
-        const bs = new BaseStemmer();
-    }
-    const Stemmer = create(lang, use_esm);
-
+// function stemming (lang : string, input : string, output : string, encoding : string) {
+function stemming (lang, input, output, encoding) {
     const lines = readline.createInterface({
         input: fs.createReadStream(input, encoding),
         terminal: false
     });
     const out = fs.createWriteStream(output, encoding);
+    const stemmer = create(lang);
     lines.on('line', (original) => {
-        out.write(Stemmer.stemWord(original) + '\n');
+        out.write(stemmer.stemWord(original) + '\n');
     });
 }
 
-function create(name, use_esm) {
+function create (name) {
     const lc_name = name.toLowerCase();
     if (/\W/.test(lc_name) || lc_name === 'base') {
         console.log('Unknown stemming language: ' + name + '\n');
@@ -107,23 +96,17 @@ function create(name, use_esm) {
         process.exit(1);
         return;
     }
-    const stemmerClass = `${titleCase(lc_name)}Stemmer`;
-    const filename = use_esm ? `${lc_name}-stemmer.esm.js` : `${lc_name}-stemmer.js`;
+    const stemmerName = `${titleCase(lc_name)}Stemmer`;
+    const filename = `${lc_name}-stemmer.js`;
     try {
-        if (use_esm) {
-            // Load stemmer class from the module scope
-            const stemmerModule = require(filename);
-            return new stemmerModule[stemmerClass]();
-        } else {
-            // Load stemmer class into the global scope
-            require(filename);
-            return new globalThis[stemmerClass]();
-        }
+        // Load stemmer class from the module scope
+        const stemmerModule = require(filename);
+        return new stemmerModule[stemmerName]();
     } catch (error) {
         console.error(error);
     }
 }
 
-function titleCase(s) {
+function titleCase (s) {
     return s.split('_').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join('');
 }

--- a/javascript/stemwords.js
+++ b/javascript/stemwords.js
@@ -2,12 +2,13 @@ const fs = require('fs');
 const readline = require('readline');
 
 function usage() {
-    console.log("usage: stemwords.js [-l <language>] -i <input file> -o <output file> [-c <character encoding>] [-h]\n");
+    console.log("usage: stemwords.js [-l <language>] -i <input file> -o <output file> [-c <character encoding>] [--esm] [-h]\n");
     console.log("The input file consists of a list of words to be stemmed, one per");
     console.log("line. Words should be in lower case.\n");
     console.log("If -c is given, the argument is the character encoding of the input");
     console.log("and output files.  If it is omitted, the UTF-8 encoding is used.\n");
     console.log("The output file consists of the stemmed words, one per line.\n");
+    console.log("Using --esm loads JavaScript Modules (ESM).\n");
     console.log("-h displays this help");
 }
 
@@ -22,6 +23,7 @@ else
     var encoding = 'utf8';
     var language = 'English';
     var show_help = false;
+    let use_esm = false;
     while (process.argv.length > 0)
     {
         var arg = process.argv.shift();
@@ -32,7 +34,7 @@ else
             process.argv.length = 0;
             break;
         case "-l":
-            if (process.argv.length == 0)
+            if (process.argv.length === 0)
             {
                 show_help = true;
                 break;
@@ -40,7 +42,7 @@ else
             language = process.argv.shift();
             break;
         case "-i":
-            if (process.argv.length == 0)
+            if (process.argv.length === 0)
             {
                 show_help = true;
                 break;
@@ -48,7 +50,7 @@ else
             input = process.argv.shift();
             break;
         case "-o":
-            if (process.argv.length == 0)
+            if (process.argv.length === 0)
             {
                 show_help = true;
                 break;
@@ -56,27 +58,30 @@ else
             output = process.argv.shift();
             break;
         case "-c":
-            if (process.argv.length == 0)
+            if (process.argv.length === 0)
             {
                 show_help = true;
                 break;
             }
             encoding = process.argv.shift();
             break;
+        case "--esm":
+            use_esm = true;
+            break;
         }
     }
-    if (show_help || input == '' || output == '')
+    if (show_help || input === '' || output === '')
     {
         usage();
     }
     else
     {
-        stemming(language, input, output, encoding);
+        stemming(language, input, output, encoding, use_esm);
     }
 }
 
-// function stemming (lang : string, input : string, output : string, encoding : string) {
-function stemming (lang, input, output, encoding) {
+// function stemming (lang : string, input : string, output : string, encoding : string, use_esm : Boolean) {
+function stemming (lang, input, output, encoding, use_esm) {
     const lines = readline.createInterface({
         input: fs.createReadStream(input, encoding),
         terminal: false
@@ -88,11 +93,13 @@ function stemming (lang, input, output, encoding) {
     });
 }
 
-function create (name) {
-    var lc_name = name.toLowerCase();
-    if (!lc_name.match('\\W') && lc_name != 'base') {
+function create (name, use_esm) {
+    let lc_name = name.toLowerCase();
+    if (!lc_name.match('\\W') && lc_name !== 'base') {
+        lc_name = `stemmer-${lc_name}`;
+        const filename = use_esm ? `${lc_name}.esm.js` : `${lc_name}.js`;
         try {
-            const Stemmer = require(lc_name + '-stemmer.js');
+            const Stemmer = require(filename);
             return new Stemmer();
         } catch (error) {
         }


### PR DESCRIPTION
cc @ojwb 

This is based on #221 with significant revisions, so I've rewritten the history but kept co-authored-by credit.

This PR:

* Removes use of the `.mjs` file extension, which [is not reccomended](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules#aside_%E2%80%94_.mjs_versus_.js). We use `.esm.js` instead, to avoid overwriting the 'global' variant.
* Rewrites `BaseStemmer` as a [JavaScript class](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_classes). The `export { BaseStemmer }` line is conditionally appended via the makefile. [It is possible](https://stackoverflow.com/a/72314371) to put this in the file itself, but too fragile for my taste.
* Removes Node.js-specific content (`module.exports`)
* Adds an 'ESM' / JS Modules variant of the JS generator to generate and export `{LANG}Stemmer` as an anonymous class via an immediately-executed function.
  * My understanding and testing is that this should work cross-file, but if not we could add `globalThis.{LANG}Stemmer = {LANG}Stemmer` to explicitly export to the global scope.
* Adds an `--esm` mode to `stemwords.js` for testing.
* Uses `const` and `let` within the bodies of 'global' variant stemmers.

I think it would be possible to rewrite the entire JS generator to use (proper) JS classes, in the style of `base-stemmer.js` in this PR. Doing this properly would enable use of `#private` fields and methods, which would remove the complexity of the current IIFEs whilst achieving the same thing. In this scenario, the difference between 'ESM' and 'Global' mode would just be the `export` line. This is more work, though.

Let me know what you think,
Adam

xref:
* #183 
* #221

Feel free to push to this branch / use as you see fit.