### PR TITLE
Remove 'module.exports' in JavaScript

### DIFF
--- a/compiler/generator_js.c
+++ b/compiler/generator_js.c
@@ -1308,8 +1308,7 @@ static void generate_class_end(struct generator * g) {
         w(g, "~N"
              "export default ~n~N");
     } else {
-        w(g, "~N"
-             "if (typeof module === 'object' && module.exports) module.exports = ~n;~N");
+        w(g, "~N");
     }
 }
 

--- a/javascript/base-stemmer.js
+++ b/javascript/base-stemmer.js
@@ -465,5 +465,3 @@ const BaseStemmer = function() {
         return result;
     };
 };
-
-if (typeof module === 'object' && module.exports) module.exports = BaseStemmer;


### PR DESCRIPTION
A much smaller alternate PR to unblock Sphinx in the immediate instance. `module.exports` prevents the files from being loaded in the browser.

A