### PR TITLE
Emit JS classes

### DIFF
--- a/compiler/generator_js.c
+++ b/compiler/generator_js.c
@@ -1077,7 +1077,7 @@ static void generate_define(struct generator * g, struct node * p) {
             generate(g, p->left->right);
         }
     }
-    w(g, "~-~M};~N");
+    w(g, "~-~M}~N");
 
     str_append(saved_output, g->declarations);
     str_append(saved_output, g->outbuf);
@@ -1282,7 +1282,7 @@ static void generate_class_end(struct generator * g) {
     w(g, "~Mthis.setCurrent(word);~N");
     w(g, "~Mthis.#stem();~N");
     w(g, "~Mreturn this.getCurrent();~N");
-    w(g, "~-~M};~N");
+    w(g, "~-~M}~N");
     w(g, "~-}~N");
     w(g, "~N");
     w(g, "export { ~n };~N");

--- a/compiler/generator_js.c
+++ b/compiler/generator_js.c
@@ -1090,22 +1090,23 @@ static void generate_substring(struct generator * g, struct node * p) {
     struct among * x = p->among;
 
     g->S[0] = p->mode == m_forward ? "" : "_b";
+    g->S[1] = x->function_count > 0 ? ", this" : "";
     g->I[0] = x->number;
 
     if (x->amongvar_needed) {
-        writef(g, "~Mamong_var = this.find_among~S0(this.#a_~I0);~N", p);
+        writef(g, "~Mamong_var = this.find_among~S0(this.#a_~I0~S1);~N", p);
         if (!x->always_matches) {
             write_failure_if(g, "among_var == 0", p);
         }
     } else if (x->always_matches) {
-        writef(g, "~Mthis.find_among~S0(this.#a_~I0);~N", p);
+        writef(g, "~Mthis.find_among~S0(this.#a_~I0~S1);~N", p);
     } else if (x->command_count == 0 &&
                x->node->right && x->node->right->type == c_functionend) {
-        writef(g, "~Mreturn this.find_among~S0(this.#a_~I0) != 0;~N", p);
+        writef(g, "~Mreturn this.find_among~S0(this.#a_~I0~S1) != 0;~N", p);
         x->node->right = NULL;
         g->unreachable = true;
     } else {
-        write_failure_if(g, "this.find_among~S0(this.#a_~I0) == 0", p);
+        write_failure_if(g, "this.find_among~S0(this.#a_~I0~S1) == 0", p);
     }
 }
 

--- a/javascript/base-stemmer.js
+++ b/javascript/base-stemmer.js
@@ -9,6 +9,7 @@ class BaseStemmer {
         this.limit_backward = 0;
         this.bra = 0;
         this.ket = 0;
+        this.af = 0;
     }
 
     /**
@@ -235,10 +236,10 @@ class BaseStemmer {
 
     /**
      * @param {Array<Array>} v
-     * @param {object} s
+     * @param {?function(): boolean} call_among_func
      * @return {number}
      */
-    find_among(v, s=null)
+    find_among(v, call_among_func)
     {
         /** @protected */
         let i = 0;
@@ -300,7 +301,8 @@ class BaseStemmer {
             {
                 this.cursor = c + w[0].length;
                 if (w.length < 4) return w[2];
-                if (w[3].call(this))
+                this.af = w[3];
+                if (call_among_func.call(this))
                 {
                     this.cursor = c + w[0].length;
                     return w[2];
@@ -314,10 +316,9 @@ class BaseStemmer {
     // find_among_b is for backwards processing. Same comments apply
     /**
      * @param {Array<Array>} v
-     * @param {object} s
-     * @return {number}
+     * @param {?function(): boolean} call_among_func
      */
-    find_among_b(v, s=null)
+    find_among_b(v, call_among_func)
     {
         /** @protected */
         let i = 0;
@@ -373,7 +374,8 @@ class BaseStemmer {
             {
                 this.cursor = c - w[0].length;
                 if (w.length < 4) return w[2];
-                if (w[3].call(this))
+                this.af = w[3];
+                if (call_among_func.call(this))
                 {
                     this.cursor = c - w[0].length;
                     return w[2];

--- a/javascript/base-stemmer.js
+++ b/javascript/base-stemmer.js
@@ -235,9 +235,10 @@ class BaseStemmer {
 
     /**
      * @param {Array<Array>} v
+     * @param {object} s
      * @return {number}
      */
-    find_among(v)
+    find_among(v, s=null)
     {
         /** @protected */
         let i = 0;
@@ -299,7 +300,7 @@ class BaseStemmer {
             {
                 this.cursor = c + w[0].length;
                 if (w.length < 4) return w[2];
-                let res = w[3](this);
+                let res = w[3].call(s);
                 this.cursor = c + w[0].length;
                 if (res) return w[2];
             }
@@ -311,9 +312,10 @@ class BaseStemmer {
     // find_among_b is for backwards processing. Same comments apply
     /**
      * @param {Array<Array>} v
+     * @param {object} s
      * @return {number}
      */
-    find_among_b(v)
+    find_among_b(v, s=null)
     {
         /** @protected */
         let i = 0;
@@ -369,7 +371,7 @@ class BaseStemmer {
             {
                 this.cursor = c - w[0].length;
                 if (w.length < 4) return w[2];
-                let res = w[3](this);
+                let res = w[3].call(s);
                 this.cursor = c - w[0].length;
                 if (res) return w[2];
             }


### PR DESCRIPTION
cc @ojwb 

This is a sketch of emitting JavaScript classes in the snowball compiler. It doesn't currently pass & needs work, but I'm not comfortable proposing changes more invasive than this.

The challenge is with the callback functions in the among arrays. A minimal example is below -- I believe that the functions will need to be changed in some way to pass explicit state or context.

A different solution would be to make the methods and fields public, but that isn't in keeping with the other programming languages, or the current JS implementation.

A

```js
class Base {
    act(w) { console.log(w[0]()); }
}
class C extends Base {
    get #arr() { console.log("#arr"); return [this.#food]; }
    get #arr2() { console.log("arr2"); return [this.food2]; }
    #lobster = "lobster";
    lobster2 = "lobster (public)";
    #food() { console.log("#food"); return this.#lobster; }
    food2() { console.log("food2"); return this.lobster2; }
    spam() { console.log("spam"); this.act(this.#arr); }
    spam2() { console.log("spam2"); this.act(this.#arr2); }
}
let c = new C();
c.spam();  // raises TypeError: can't access private field or method
c.spam2();  // logs 'undefined' instead of 'lobster'
```