### PR TITLE
Polish Stemmer v3

### DIFF
--- a/algorithms/polish.sbl
+++ b/algorithms/polish.sbl
@@ -17,10 +17,7 @@ externals (stem)
 
 routines (
   mark_regions
-  adjectival
-  verb
-  short_verb
-  verb2
+  verb_or_adjective
   noun
   normalize_consonant
 )
@@ -39,47 +36,7 @@ define mark_regions as (
 )
 
 backwardmode (
-  define adjectival as (
-    // This function handles adjectives (including comparative/superlative forms)
-    // as well as participles.
-    [substring] among (
-      'y'          // singular masculine nominative (nowy)
-      'ego' 'iego' // singular masculine genitive (nowego, polskiego)
-      'emu' 'iemu' // singular masculine dative (nowemu, polskiemu)
-      'ym'  'im'   // singular masculine instrumental (nowym, polskim)
-      'ej'  'iej'  // singular feminine genitive (nowej, polskiej)
-      'ych' 'ich'  // plural genitive (nowych, polskich)
-      'ymi' 'imi'  // plural instrumental (nowymi, polskimi)
-        (
-          delete
-          try (
-            [substring] among (
-              'aj{ak}c'  // participle suffix (czytający)
-              '{ak}c'    // participle suffix (lecący)
-              'iejsz'    // comparative suffix (piękniejszy)
-              'sz'       // comparative suffix (lepszy)
-                (delete)
-              'sz{ak}c'  // participle suffix (noszący)
-                (<- 's')
-            )
-          )
-        )
-      // We cannot remove endings like -ą and -e unconditionally, because these
-      // letters appear in too many contexts. But we can safely remove them if we
-      // know that our word is a participle or a comparative/superlative form.
-      'aj{ak}ca'    '{ak}ca'    'iejsza'    'sza'    // singular feminine nominative (czytająca, lecąca, piękniejsza, lepsza)
-      'aj{ak}c{ak}' '{ak}c{ak}' 'iejsz{ak}' 'sz{ak}' // singular feminine accusative (czytającą, lecącą, piękniejszą, lepszą)
-      'aj{ak}ce'    '{ak}ce'    'iejsze'    'sze'    // singular neuter nominative (czytające, lecące, piękniejsze, lepsze)
-        (delete)
-      // Handle participles like nosząca, prosząca.
-      'sz{ak}ca'
-      'sz{ak}c{ak}'
-      'sz{ak}ce'
-        (<- 's')
-    )
-  )
-
-  define verb as (
+  define verb_or_adjective as (
     do (
       setlimit tomark p1 for ([substring]) among (
         // conditionals:
@@ -120,6 +77,13 @@ backwardmode (
       'ajcie'  // imperative 2nd person plural (czytajcie)
       'cie'    // imperative 2nd person plural (chodźcie)
         (delete)
+      'sz{ek}' // present 1st person singular (noszę)
+// Also an adjectival form below (singular feminine accusative).
+// Currently noszą -> no.  FIXME When to apply each rule?
+//      'sz{ak}' // present 3rd person plural (noszą)
+        (<- 's')
+      '{ek}'   // present 1st person singular (lecę)
+        (delete)
 
       // There are short verbs whose root consists of only one consonant, e.g. być, żyć.
       // Stemming them to one letter would merge them with these letters used in other
@@ -132,25 +96,50 @@ backwardmode (
       'li{s'}cie'
       '{l/}y{s'}cie'
         (<- '{l/}')
-    )
-  )
 
-  define verb2 as (
-    // -szą can be also part of comparative forms like piękniejszą,
-    // so we need to process it after we are done with adjectival forms.
-    [substring] among (
-      'sz{ek}' // present 1st person singular (noszę)
-      'sz{ak}' // present 3rd person plural (noszą)
-        (<- 's')
-      '{ek}'   // present 1st person singular (lecę)
+      // Adjectives (including comparative/superlative forms)
+      // as well as participles.
+      'y'          // singular masculine nominative (nowy)
+      'ego' 'iego' // singular masculine genitive (nowego, polskiego)
+      'emu' 'iemu' // singular masculine dative (nowemu, polskiemu)
+      'ym'  'im'   // singular masculine instrumental (nowym, polskim)
+      'ej'  'iej'  // singular feminine genitive (nowej, polskiej)
+      'ych' 'ich'  // plural genitive (nowych, polskich)
+      'ymi' 'imi'  // plural instrumental (nowymi, polskimi)
+        (
+          delete
+          try (
+            [substring] among (
+              'aj{ak}c'  // participle suffix (czytający)
+              '{ak}c'    // participle suffix (lecący)
+              'iejsz'    // comparative suffix (piękniejszy)
+              'sz'       // comparative suffix (lepszy)
+                (delete)
+              'sz{ak}c'  // participle suffix (noszący)
+                (<- 's')
+            )
+          )
+        )
+      // We cannot remove endings like -ą and -e unconditionally, because these
+      // letters appear in too many contexts. But we can safely remove them if we
+      // know that our word is a participle or a comparative/superlative form.
+      'aj{ak}ca'    '{ak}ca'    'iejsza'    'sza'    // singular feminine nominative (czytająca, lecąca, piękniejsza, lepsza)
+      'aj{ak}c{ak}' '{ak}c{ak}' 'iejsz{ak}' 'sz{ak}' // singular feminine accusative (czytającą, lecącą, piękniejszą, lepszą)
+      'aj{ak}ce'    '{ak}ce'    'iejsze'    'sze'    // singular neuter nominative (czytające, lecące, piękniejsze, lepsze)
         (delete)
+      // Handle participles like nosząca, prosząca.
+      'sz{ak}ca'
+      'sz{ak}c{ak}'
+      'sz{ak}ce'
+        (<- 's')
     )
   )
 
   define noun as (
     setlimit tomark p1 for ([substring]) among (
       'a' 'o'                   // singular nominative (książka, lato)
-      'i' 'y' 'u' 'ia'          // singular genitive (książki, kobiety, stołu, słonia)
+      // 'y' removed as an adjectival ending.
+      'i' /*'y'*/ 'u' 'ia'          // singular genitive (książki, kobiety, stołu, słonia)
       'owi' 'iowi'              // singular dative (stołowi, słoniowi)
       '{ak}' 'i{ak}' 'em' 'iem' // singular instrumental (książką, możliwością, stołem, słoniem)
       'e' 'iu'                  // singular locative (stole, słoniu)
@@ -182,10 +171,8 @@ define stem as (
   (
     hop 2
     backwards (
-      verb
-      or adjectival
+      verb_or_adjective
       or noun
-      or verb2
     )
   ) or (
     backwards normalize_consonant

--- a/algorithms/polish.sbl
+++ b/algorithms/polish.sbl
@@ -17,9 +17,10 @@ externals (stem)
 
 routines (
   mark_regions
-  verb_or_adjective
+  remove_endings
   noun
   normalize_consonant
+  R1
 )
 
 integers ( p1 )
@@ -36,7 +37,9 @@ define mark_regions as (
 )
 
 backwardmode (
-  define verb_or_adjective as (
+  define R1 as ($p1 <= cursor)
+
+  define remove_endings as (
     do (
       setlimit tomark p1 for ([substring]) among (
         // conditionals:
@@ -132,22 +135,19 @@ backwardmode (
       'sz{ak}c{ak}'
       'sz{ak}ce'
         (<- 's')
-    )
-  )
 
-  define noun as (
-    setlimit tomark p1 for ([substring]) among (
-      'a' 'o'                   // singular nominative (książka, lato)
+      // Noun forms.
+      'a' R1 'o' R1                  // singular nominative (książka, lato)
       // 'y' removed as an adjectival ending.
-      'i' /*'y'*/ 'u' 'ia'          // singular genitive (książki, kobiety, stołu, słonia)
-      'owi' 'iowi'              // singular dative (stołowi, słoniowi)
-      '{ak}' 'i{ak}' 'em' 'iem' // singular instrumental (książką, możliwością, stołem, słoniem)
-      'e' 'iu'                  // singular locative (stole, słoniu)
-      'ie'                      // plural nominative (słonie)
-      '{o'}w'                   // plural genitive (stołów)
-      'om'  'iom'               // plural dative (książkom, słoniom)
-      'ami' 'iami'              // plural instrumental (książkami, słoniami)
-      'ach' 'iach'              // plural locative (książkach, słoniach)
+      'i' R1 /*'y'*/ 'u' R1 'ia' R1          // singular genitive (książki, kobiety, stołu, słonia)
+      'owi' R1 'iowi' R1              // singular dative (stołowi, słoniowi)
+      '{ak}' R1 'i{ak}' R1 'em' R1 'iem' R1 // singular instrumental (książką, możliwością, stołem, słoniem)
+      'e' R1 'iu' R1                  // singular locative (stole, słoniu)
+      'ie' R1                      // plural nominative (słonie)
+      '{o'}w' R1                   // plural genitive (stołów)
+      'om' R1  'iom' R1               // plural dative (książkom, słoniom)
+      'ami' R1 'iami' R1              // plural instrumental (książkami, słoniami)
+      'ach' R1 'iach' R1              // plural locative (książkach, słoniach)
         (delete)
     )
   )
@@ -170,10 +170,7 @@ define stem as (
   // set the backwards limit to the current cursor position.
   (
     hop 2
-    backwards (
-      verb_or_adjective
-      or noun
-    )
+    backwards remove_endings
   ) or (
     backwards normalize_consonant
   )

--- a/algorithms/polish.sbl
+++ b/algorithms/polish.sbl
@@ -1,0 +1,200 @@
+/* Polish stemmer. Author: Dmitry Shachnev */
+
+stringescapes {}
+
+stringdef ak '{U+0105}' // ą a + ogonek
+stringdef ek '{U+0119}' // ę e + ogonek
+stringdef l/ '{U+0142}' // ł l + stroke
+stringdef c' '{U+0107}' // ć c + acute (kreska)
+stringdef n' '{U+0144}' // ń n + acute (kreska)
+stringdef o' '{U+00f3}' // ó o + acute (kreska)
+stringdef s' '{U+015b}' // ś s + acute (kreska)
+stringdef z' '{U+017a}' // ź z + acute (kreska)
+
+
+externals (stem)
+
+
+routines (
+  mark_regions
+  adjectival
+  verb
+  short_verb
+  verb2
+  noun
+  normalize_consonant
+)
+
+integers ( p0 p1 )
+
+groupings ( v )
+
+define v 'a{ak}e{ek}io{o'}uy'
+
+
+define mark_regions as (
+  $p0 = limit
+  $p1 = limit
+
+  // Make sure we don't produce too short outputs.
+  test (hop 2 setmark p0)
+
+  gopast v
+  gopast non-v  setmark p1
+)
+
+backwardmode (
+  define adjectival as (
+    // This function handles adjectives (including comparative/superlative forms)
+    // as well as participles.
+    setlimit tomark p0 for ([substring]) among (
+      'y'          // singular masculine nominative (nowy)
+      'ego' 'iego' // singular masculine genitive (nowego, polskiego)
+      'emu' 'iemu' // singular masculine dative (nowemu, polskiemu)
+      'ym'  'im'   // singular masculine instrumental (nowym, polskim)
+      'ej'  'iej'  // singular feminine genitive (nowej, polskiej)
+      'ych' 'ich'  // plural genitive (nowych, polskich)
+      'ymi' 'imi'  // plural instrumental (nowymi, polskimi)
+        (
+          delete
+          try (
+            setlimit tomark p0 for ([substring]) among (
+              'aj{ak}c'  // participle suffix (czytający)
+              '{ak}c'    // participle suffix (lecący)
+              'iejsz'    // comparative suffix (piękniejszy)
+              'sz'       // comparative suffix (lepszy)
+                (delete)
+              'sz{ak}c'  // participle suffix (noszący)
+                (<- 's')
+            )
+          )
+        )
+      // We cannot remove endings like -ą and -e unconditionally, because these
+      // letters appear in too many contexts. But we can safely remove them if we
+      // know that our word is a participle or a comparative/superlative form.
+      'aj{ak}ca'    '{ak}ca'    'iejsza'    'sza'    // singular feminine nominative (czytająca, lecąca, piękniejsza, lepsza)
+      'aj{ak}c{ak}' '{ak}c{ak}' 'iejsz{ak}' 'sz{ak}' // singular feminine accusative (czytającą, lecącą, piękniejszą, lepszą)
+      'aj{ak}ce'    '{ak}ce'    'iejsze'    'sze'    // singular neuter nominative (czytające, lecące, piękniejsze, lepsze)
+        (delete)
+      // Handle participles like nosząca, prosząca.
+      'sz{ak}ca'
+      'sz{ak}c{ak}'
+      'sz{ak}ce'
+        (<- 's')
+    )
+  )
+
+  define verb as (
+    do (
+      setlimit tomark p1 for ([substring]) among (
+        // conditionals:
+        'bym'        // 1st person singular (czytał(a)bym)
+        'by{s'}'     // 2nd person singular (czytał(a)byś)
+        'by{s'}my'   // 1st person plural (czytalibyśmy)
+        'by{s'}cie'  // 2nd person plural (czytalibyście)
+        'by'         // 3rd person singular/plural (czytał(a)by, czytaliby)
+          (delete)
+      )
+    )
+    setlimit tomark p0 for ([substring]) among (
+      'asz'  'esz'  'isz'  // present 2nd person singular (czytasz, piszesz, nosisz)
+      'amy'  'emy'  'imy'  // present 1st person plural (czytamy, piszemy, nosimy)
+      'acie' 'ecie' 'icie' // present 2nd person plural (czytacie, piszecie, nosicie)
+      'aj{ak}'             // present 3rd person plural (czytają)
+      'e{s'}{c'}'          // infinitive (przynieść)
+      'a{s'}{c'}'          // infinitive (popaść)
+      'a{c'}'              // infinitive (czytać)
+      'ie{c'}'             // infinitive (lecieć)
+      'i{c'}'              // infinitive (wozić)
+      '{ak}{c'}'           // infinitive (marznąć)
+      'aj{ak}c' '{ak}c'    // contemporary adverbial participle (transgressive) (czytając, lecąc)
+      'a{l/}em'       'ia{l/}em'       'i{l/}em'       // past 1st person singular masculine (czytałem, leciałem, chodziłem)
+      'a{l/}am'       'ia{l/}am'       'i{l/}am'  'am' // past 1st person singular feminine (czytałam, leciałam, chodziłam, marzłam)
+      'a{l/}e{s'}'    'ia{l/}e{s'}'    'i{l/}e{s'}'    // past 2nd person singular masculine (czytałeś, leciałeś, chodziłeś)
+      'a{l/}a{s'}'    'ia{l/}a{s'}'    'i{l/}a{s'}'    // past 2nd person singular feminine (czytałaś, leciałaś, chodziłaś)
+      'a{l/}'         'ia{l/}'         'i{l/}'         // past 3rd person singular masculine (czytał, leciał, chodził)
+      'a{l/}a'        'ia{l/}a'        'i{l/}a'        // past 3rd person singular feminine (czytała, leciała, chodziła)
+      'a{l/}o'        'ia{l/}o'        'i{l/}o'        // past 3rd person singular neuter (czytało, leciało, chodziło)
+      'ali{s'}my'     'ieli{s'}my'     'ili{s'}my'     // past 1st person plural virile (czytaliśmy, lecieliśmy, chodziliśmy)
+      'a{l/}y{s'}my'  'ia{l/}y{s'}my'  'i{l/}y{s'}my'  // past 1st person plural nonvirile (czytałyśmy, leciałyśmy, chodziłyśmy)
+      'ali{s'}cie'    'ieli{s'}cie'    'ili{s'}cie'    // past 2nd person plural virile (czytaliście, lecieliście, chodziliście)
+      'a{l/}y{s'}cie' 'ia{l/}y{s'}cie' 'i{l/}y{s'}cie' // past 2nd person plural nonvirile (czytałyście, leciałyście, chodziłyście)
+      'ali'           'ieli'           'ili'           // past 3rd person plural virile (czytali, lecieli, chodzili)
+      'a{l/}y'        'ia{l/}y'        'i{l/}y'        // past 3rd person plural nonvirile (czytały, leciały, chodziły)
+      'aj'     // imperative 2nd person singular (czytaj)
+      'ajcie'  // imperative 2nd person plural (czytajcie)
+        (delete)
+    )
+  )
+
+  define short_verb as (
+    // There are short verbs whose root consists of only one consonant, e.g. być, żyć.
+    // Stemming them to one letter would merge them with these letters used in other
+    // contexts, which is undesirable. But let's at least merge all past tense forms
+    // together, e.g. byłem, byłam, byłyśmy, etc. to był.
+    ([substring]) among (
+      '{l/}e{s'}'
+      '{l/}a{s'}'
+      'li{s'}my'
+      '{l/}y{s'}my'
+      'li{s'}cie'
+      '{l/}y{s'}cie'
+        (<- '{l/}')
+      // Handle the imperative 2nd person plural form (chodźcie) here as well.
+      // We cannot do that earlier, because that would also affect the 2nd person
+      // plural past tense forms.
+      'cie'
+        (delete)
+    )
+  )
+
+  define verb2 as (
+    // -szą can be also part of comparative forms like piękniejszą,
+    // so we need to process it after we are done with adjectival forms.
+    setlimit tomark p0 for ([substring]) among (
+      'sz{ek}' // present 1st person singular (noszę)
+      'sz{ak}' // present 3rd person plural (noszą)
+        (<- 's')
+      '{ek}'   // present 1st person singular (lecę)
+        (delete)
+    )
+  )
+
+  define noun as (
+    setlimit tomark p1 for ([substring]) among (
+      'a' 'o'                   // singular nominative (książka, lato)
+      'i' 'y' 'u' 'ia'          // singular genitive (książki, kobiety, stołu, słonia)
+      'owi' 'iowi'              // singular dative (stołowi, słoniowi)
+      '{ak}' 'i{ak}' 'em' 'iem' // singular instrumental (książką, możliwością, stołem, słoniem)
+      'e' 'iu'                  // singular locative (stole, słoniu)
+      'ie'                      // plural nominative (słonie)
+      '{o'}w'                   // plural genitive (stołów)
+      'om'  'iom'               // plural dative (książkom, słoniom)
+      'ami' 'iami'              // plural instrumental (książkami, słoniami)
+      'ach' 'iach'              // plural locative (książkach, słoniach)
+        (delete)
+    )
+  )
+
+  define normalize_consonant as (
+    // Remove kreska mark, because most of oblique cases do not have it.
+    [substring] among (
+      '{c'}' (<- 'c') // e.g. miłość → miłośc
+      '{n'}' (<- 'n') // e.g. słoń → słon
+      '{s'}' (<- 's') // e.g. gęś → gęs
+      '{z'}' (<- 'z') // e.g. miedź → miedz
+    )
+  )
+)
+
+define stem as (
+  do mark_regions
+  backwards (
+    verb
+    or short_verb
+    or adjectival
+    or noun
+    or normalize_consonant
+    or verb2
+  )
+)

--- a/algorithms/polish.sbl
+++ b/algorithms/polish.sbl
@@ -25,7 +25,7 @@ routines (
   normalize_consonant
 )
 
-integers ( p0 p1 )
+integers ( p1 )
 
 groupings ( v )
 
@@ -33,12 +33,7 @@ define v 'a{ak}e{ek}io{o'}uy'
 
 
 define mark_regions as (
-  $p0 = limit
   $p1 = limit
-
-  // Make sure we don't produce too short outputs.
-  test (hop 2 setmark p0)
-
   gopast v
   gopast non-v  setmark p1
 )
@@ -47,7 +42,7 @@ backwardmode (
   define adjectival as (
     // This function handles adjectives (including comparative/superlative forms)
     // as well as participles.
-    setlimit tomark p0 for ([substring]) among (
+    [substring] among (
       'y'          // singular masculine nominative (nowy)
       'ego' 'iego' // singular masculine genitive (nowego, polskiego)
       'emu' 'iemu' // singular masculine dative (nowemu, polskiemu)
@@ -58,7 +53,7 @@ backwardmode (
         (
           delete
           try (
-            setlimit tomark p0 for ([substring]) among (
+            [substring] among (
               'aj{ak}c'  // participle suffix (czytający)
               '{ak}c'    // participle suffix (lecący)
               'iejsz'    // comparative suffix (piękniejszy)
@@ -96,7 +91,7 @@ backwardmode (
           (delete)
       )
     )
-    setlimit tomark p0 for ([substring]) among (
+    [substring] among (
       'asz'  'esz'  'isz'  // present 2nd person singular (czytasz, piszesz, nosisz)
       'amy'  'emy'  'imy'  // present 1st person plural (czytamy, piszemy, nosimy)
       'acie' 'ecie' 'icie' // present 2nd person plural (czytacie, piszecie, nosicie)
@@ -151,7 +146,7 @@ backwardmode (
   define verb2 as (
     // -szą can be also part of comparative forms like piękniejszą,
     // so we need to process it after we are done with adjectival forms.
-    setlimit tomark p0 for ([substring]) among (
+    [substring] among (
       'sz{ek}' // present 1st person singular (noszę)
       'sz{ak}' // present 3rd person plural (noszą)
         (<- 's')
@@ -178,7 +173,8 @@ backwardmode (
 
   define normalize_consonant as (
     // Remove kreska mark, because most of oblique cases do not have it.
-    [substring] among (
+    // Don't mutate single character inputs.
+    [substring] not atlimit among (
       '{c'}' (<- 'c') // e.g. miłość → miłośc
       '{n'}' (<- 'n') // e.g. słoń → słon
       '{s'}' (<- 's') // e.g. gęś → gęs
@@ -189,12 +185,18 @@ backwardmode (
 
 define stem as (
   do mark_regions
-  backwards (
-    verb
-    or short_verb
-    or adjectival
-    or noun
-    or normalize_consonant
-    or verb2
+  // Make sure we don't produce too short outputs.  The "backwards" will
+  // set the backwards limit to the current cursor position.
+  (
+    hop 2
+    backwards (
+      verb
+      or short_verb
+      or adjectival
+      or noun
+      or verb2
+    )
+  ) or (
+    backwards normalize_consonant
   )
 )

--- a/algorithms/polish.sbl
+++ b/algorithms/polish.sbl
@@ -118,16 +118,13 @@ backwardmode (
       'a{l/}y'        'ia{l/}y'        'i{l/}y'        // past 3rd person plural nonvirile (czytały, leciały, chodziły)
       'aj'     // imperative 2nd person singular (czytaj)
       'ajcie'  // imperative 2nd person plural (czytajcie)
+      'cie'    // imperative 2nd person plural (chodźcie)
         (delete)
-    )
-  )
 
-  define short_verb as (
-    // There are short verbs whose root consists of only one consonant, e.g. być, żyć.
-    // Stemming them to one letter would merge them with these letters used in other
-    // contexts, which is undesirable. But let's at least merge all past tense forms
-    // together, e.g. byłem, byłam, byłyśmy, etc. to był.
-    ([substring]) among (
+      // There are short verbs whose root consists of only one consonant, e.g. być, żyć.
+      // Stemming them to one letter would merge them with these letters used in other
+      // contexts, which is undesirable. But let's at least merge all past tense forms
+      // together, e.g. byłem, byłam, byłyśmy, etc. to był.
       '{l/}e{s'}'
       '{l/}a{s'}'
       'li{s'}my'
@@ -135,11 +132,6 @@ backwardmode (
       'li{s'}cie'
       '{l/}y{s'}cie'
         (<- '{l/}')
-      // Handle the imperative 2nd person plural form (chodźcie) here as well.
-      // We cannot do that earlier, because that would also affect the 2nd person
-      // plural past tense forms.
-      'cie'
-        (delete)
     )
   )
 
@@ -191,7 +183,6 @@ define stem as (
     hop 2
     backwards (
       verb
-      or short_verb
       or adjectival
       or noun
       or verb2

--- a/algorithms/polish.sbl
+++ b/algorithms/polish.sbl
@@ -18,7 +18,6 @@ externals (stem)
 routines (
   mark_regions
   remove_endings
-  noun
   normalize_consonant
   R1
 )

--- a/algorithms/polish.sbl
+++ b/algorithms/polish.sbl
@@ -40,6 +40,7 @@ backwardmode (
   define R1 as ($p1 <= cursor)
 
   define remove_endings as (
+    // Verbs.
     do (
       setlimit tomark p1 for ([substring]) among (
         // conditionals:
@@ -79,6 +80,7 @@ backwardmode (
       'aj'     // imperative 2nd person singular (czytaj)
       'ajcie'  // imperative 2nd person plural (czytajcie)
       'cie'    // imperative 2nd person plural (chodźcie)
+      '{ek}'   // present 1st person singular (lecę)
         (delete)
       'sz{ek}' // present 1st person singular (noszę)
         (<- 's')
@@ -86,8 +88,6 @@ backwardmode (
         // Also an adjectival form (singular feminine accusative), e.g. lepszą.
         // This heuristic does the right thing in common cases.
         (R1 and delete or <-'s')
-      '{ek}'   // present 1st person singular (lecę)
-        (delete)
 
       // There are short verbs whose root consists of only one consonant, e.g. być, żyć.
       // Stemming them to one letter would merge them with these letters used in other
@@ -127,9 +127,9 @@ backwardmode (
       // We cannot remove endings like -ą and -e unconditionally, because these
       // letters appear in too many contexts. But we can safely remove them if we
       // know that our word is a participle or a comparative/superlative form.
-      'aj{ak}ca'    '{ak}ca'    'iejsza'    'sza'    // singular feminine nominative (czytająca, lecąca, piękniejsza, lepsza)
-      'aj{ak}c{ak}' '{ak}c{ak}' 'iejsz{ak}'          // singular feminine accusative (czytającą, lecącą, piękniejszą); -szą is handled separately
-      'aj{ak}ce'    '{ak}ce'    'iejsze'    'sze'    // singular neuter nominative (czytające, lecące, piękniejsze, lepsze)
+      'aj{ak}ca'    '{ak}ca'    'iejsza'    'sza'  // singular feminine nominative (czytająca, lecąca, piękniejsza, lepsza)
+      'aj{ak}c{ak}' '{ak}c{ak}' 'iejsz{ak}'        // singular feminine accusative (czytającą, lecącą, piękniejszą); -szą is handled separately
+      'aj{ak}ce'    '{ak}ce'    'iejsze'    'sze'  // singular neuter nominative (czytające, lecące, piękniejsze, lepsze)
         (delete)
       // Handle participles like nosząca, prosząca.
       'sz{ak}ca'
@@ -137,18 +137,17 @@ backwardmode (
       'sz{ak}ce'
         (<- 's')
 
-      // Noun forms.
-      'a' R1 'o' R1                  // singular nominative (książka, lato)
-      // 'y' removed as an adjectival ending.
-      'i' R1 /*'y'*/ 'u' R1 'ia' R1          // singular genitive (książki, kobiety, stołu, słonia)
-      'owi' R1 'iowi' R1              // singular dative (stołowi, słoniowi)
-      '{ak}' R1 'i{ak}' R1 'em' R1 'iem' R1 // singular instrumental (książką, możliwością, stołem, słoniem)
-      'e' R1 'iu' R1                  // singular locative (stole, słoniu)
-      'ie' R1                      // plural nominative (słonie)
-      '{o'}w' R1                   // plural genitive (stołów)
-      'om' R1  'iom' R1               // plural dative (książkom, słoniom)
-      'ami' R1 'iami' R1              // plural instrumental (książkami, słoniami)
-      'ach' R1 'iach' R1              // plural locative (książkach, słoniach)
+      // Noun forms (excluding endings that were already handled above).
+      'a' R1  'o' R1                            // singular nominative (książka, lato)
+      'i' R1  'u' R1  'ia' R1                   // singular genitive (książki, stołu, słonia)
+      'owi' R1  'iowi' R1                       // singular dative (stołowi, słoniowi)
+      '{ak}' R1  'i{ak}' R1  'em' R1  'iem' R1  // singular instrumental (książką, możliwością, stołem, słoniem)
+      'e' R1  'iu' R1                           // singular locative (stole, słoniu)
+      'ie' R1                                   // plural nominative (słonie)
+      '{o'}w' R1                                // plural genitive (stołów)
+      'om' R1   'iom' R1                        // plural dative (książkom, słoniom)
+      'ami' R1  'iami' R1                       // plural instrumental (książkami, słoniami)
+      'ach' R1  'iach' R1                       // plural locative (książkach, słoniach)
         (delete)
     )
   )

--- a/algorithms/polish.sbl
+++ b/algorithms/polish.sbl
@@ -81,10 +81,11 @@ backwardmode (
       'cie'    // imperative 2nd person plural (chodźcie)
         (delete)
       'sz{ek}' // present 1st person singular (noszę)
-// Also an adjectival form below (singular feminine accusative).
-// Currently noszą -> no.  FIXME When to apply each rule?
-//      'sz{ak}' // present 3rd person plural (noszą)
         (<- 's')
+      'sz{ak}' // present 3rd person plural (noszą)
+        // Also an adjectival form (singular feminine accusative), e.g. lepszą.
+        // This heuristic does the right thing in common cases.
+        (R1 and delete or <-'s')
       '{ek}'   // present 1st person singular (lecę)
         (delete)
 
@@ -127,7 +128,7 @@ backwardmode (
       // letters appear in too many contexts. But we can safely remove them if we
       // know that our word is a participle or a comparative/superlative form.
       'aj{ak}ca'    '{ak}ca'    'iejsza'    'sza'    // singular feminine nominative (czytająca, lecąca, piękniejsza, lepsza)
-      'aj{ak}c{ak}' '{ak}c{ak}' 'iejsz{ak}' 'sz{ak}' // singular feminine accusative (czytającą, lecącą, piękniejszą, lepszą)
+      'aj{ak}c{ak}' '{ak}c{ak}' 'iejsz{ak}'          // singular feminine accusative (czytającą, lecącą, piękniejszą); -szą is handled separately
       'aj{ak}ce'    '{ak}ce'    'iejsze'    'sze'    // singular neuter nominative (czytające, lecące, piękniejsze, lepsze)
         (delete)
       // Handle participles like nosząca, prosząca.

--- a/libstemmer/modules.txt
+++ b/libstemmer/modules.txt
@@ -30,6 +30,7 @@ italian         UTF_8,ISO_8859_1        italian,it,ita
 lithuanian      UTF_8                   lithuanian,lt,lit
 nepali          UTF_8                   nepali,ne,nep
 norwegian       UTF_8,ISO_8859_1        norwegian,no,nor
+polish          UTF_8,ISO_8859_2        polish,pl,pol
 portuguese      UTF_8,ISO_8859_1        portuguese,pt,por
 romanian        UTF_8                   romanian,ro,rum,ron
 russian         UTF_8,KOI8_R            russian,ru,rus


### PR DESCRIPTION
This PR supersedes #159 and #220.

I rewrote the Polish stemmer almost from scratch. The main differences compared to previous approaches are:

- I ignore derivational suffixes and focus on inflectional suffixes. Also I ignore the `naj-` superlative prefix. This allows me to keep the code cleaner.
- The list of endings is more systematic and ordered. I tried to cover as many different forms and declension/conjugation patterns as possible.
- The functions are grouped using `or`, not using `do`.
- Added a new step to remove trailing *kreska*, which indicates softness of consonant (like Russian ь) and is missing in most oblique cases because they have other letters on the end.

I decided to make a new PR, first because this is a rewrite so most of old comments are irrelevant, and second to make it easier to compare this approach with the previous ones.

This PR has only one FIXME comment. I tried to resolve it by making p0 hardcoded (`$p0 = 2`), but that behaves differently in UTF-8 and ISO-8859-2 encodings, so I did not go this way after all.