### PR TITLE
Fix java code generation for $ operator

### DIFF
--- a/compiler/generator_java.c
+++ b/compiler/generator_java.c
@@ -886,9 +886,8 @@ static void generate_dollar(struct generator * g, struct node * p) {
     str_assign(g->failure_str, "copy_from(");
     str_append(g->failure_str, savevar);
     str_append_string(g->failure_str, ");");
-    writef(g, "~Mcurrent = ~V;~N"
-              "~Mcursor = 0;~N"
-              "~Mlimit = current.length();~N", p);
+    /* TODO: not optimal */
+    writef(g, "~MsetCurrent(~V.toString());~N", p);
     generate(g, p->left);
     if (!g->unreachable) {
         write_margin(g);


### PR DESCRIPTION
The internal `current` variable is private and not accessible by the stemmer, and is of type `char[]` which won't work via assignment from a StringBuilder.

Call `setCurrent()` so that the generator creates working valid code.

Closes #252

@ojwb Given none of the current algorithms exercise this, I'm hesitant to try to "optimize" this case in fear I might introduce a bug. With a modern java version this shouldn't be too bad, an unnecessary String object is allocated, but escape analysis should work to reduce any overhead as long as `setCurrent()` can be inlined, I think.