### PR TITLE
Java: Fix string-$

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -121,6 +121,7 @@ RUNTIME_HEADERS  = runtime/api.h \
 		   runtime/header.h
 
 JAVARUNTIME_SOURCES = java/org/tartarus/snowball/Among.java \
+		      java/org/tartarus/snowball/CharArraySequence.java \
 		      java/org/tartarus/snowball/SnowballProgram.java \
 		      java/org/tartarus/snowball/SnowballStemmer.java \
 		      java/org/tartarus/snowball/TestApp.java

--- a/compiler/generator.c
+++ b/compiler/generator.c
@@ -1961,6 +1961,8 @@ extern struct generator * create_generator(struct analyser * a, struct options *
 #ifndef DISABLE_PYTHON
     g->max_label = 0;
 #endif
+    g->java_import_arrays = false;
+    g->java_import_chararraysequence = false;
     return g;
 }
 

--- a/compiler/header.h
+++ b/compiler/header.h
@@ -382,6 +382,8 @@ struct generator {
     int keep_count;      /* used to number keep/restore pairs to avoid compiler warnings
                             about shadowed variables */
     int temporary_used;  /* track if temporary variable used (Ada and Pascal) */
+    char java_import_arrays; /* need `import java.util.Arrays;` */
+    char java_import_chararraysequence; /* need `import org.tartarus.snowball.CharArraySequence;` */
 };
 
 /* Special values for failure_label in struct generator. */

--- a/java/org/tartarus/snowball/CharArraySequence.java
+++ b/java/org/tartarus/snowball/CharArraySequence.java
@@ -1,0 +1,36 @@
+package org.tartarus.snowball;
+
+/**
+ * Internal class used by Snowball stemmers
+ */
+public class CharArraySequence implements CharSequence {
+    public CharArraySequence(char[] a, int len) {
+        this.a = a;
+        this.len = len;
+    }
+
+    final public char charAt(int index) {
+        if (index < 0 || index >= len) {
+            throw new StringIndexOutOfBoundsException(index);
+        }
+        return a[index];
+    }
+
+    final public int length() {
+        return len;
+    }
+
+    final public CharSequence subSequence(int start, int end) {
+        // Not needed for how we used CharSequence.
+        throw new UnsupportedOperationException();
+    }
+
+    final public String toString() {
+        if (a == null) return "";
+        return new String(a, 0, len);
+    }
+
+    final private char[] a;
+
+    final private int len;
+}

--- a/java/org/tartarus/snowball/SnowballProgram.java
+++ b/java/org/tartarus/snowball/SnowballProgram.java
@@ -77,7 +77,7 @@ public class SnowballProgram implements Serializable {
     }
 
     // current string
-    private char[] current;
+    protected char[] current;
 
     protected int cursor;
     protected int length;
@@ -424,21 +424,6 @@ public class SnowballProgram implements Serializable {
         int adjustment = replace_s(c_bra, c_ket, s);
         if (c_bra <= bra) bra += adjustment;
         if (c_bra <= ket) ket += adjustment;
-    }
-
-    /* Copy the slice into the supplied StringBuilder */
-    protected void slice_to(StringBuilder s)
-    {
-        slice_check();
-        int len = ket - bra;
-        s.setLength(0);
-        s.append(current, bra, len);
-    }
-
-    protected void assign_to(StringBuilder s)
-    {
-        s.setLength(0);
-        s.append(current, 0, limit);
     }
 
 /*


### PR DESCRIPTION
We now use char[] for string variables as well as the current string, which makes it much simpler to switch to working on a string variable and back.

Fixes #252
Closes #253