### PR TITLE
Javascript: generate public functions for all externals

### DIFF
--- a/compiler/generator_js.c
+++ b/compiler/generator_js.c
@@ -1145,12 +1145,9 @@ static void generate_define(struct generator * g, struct node * p) {
         w(g, "~Mreturn this.getCurrent();~N");
         w(g, "~-~M}~N");
 
-        if (!strcmp((const char *) q->s, "stem")) {
+        if (SIZE(q->s) == 4 && memcmp(q->s, "stem", 4) == 0) {
             w(g, "~N");
-            w(g, "~M/**@return{string}*/~N");
-            w(g, "~MstemWord(/**string*/word) {~+~N");
-            w(g, "~Mthis.stem(word);~N");
-            w(g, "~-~M}~N");
+            w(g, "~MstemWord = this.stem;~N");
         }
     }
 


### PR DESCRIPTION
Adds a public function to the JS class for each external routine, which does the same getting & setting of the current word as `stemWord`.

~I've left `stemWord` untouched for backwards compatibility - not sure if that's the right thing to do, it creates a reference to a non-existent `#stem` function if the program you're writing isn't a stemmer, although that's not a problem in practice.~

The `stemWord` function is now added only if there is an external with the exact name `stem`.

Addresses one of the minor points in #244