### PR TITLE
Added more consistent word endings to Lithuanian stemmer

### DIFF
--- a/algorithms/lithuanian.sbl
+++ b/algorithms/lithuanian.sbl
@@ -44,7 +44,7 @@ backwardmode (
     setlimit tomark p1 for ([substring]) among (
       // Daiktavardžiai (Nouns)
       // I linksniuotė (declension I)
-      'as' 'ias' 'is' 'ys' 'eris' // vyras, kelias, brolis, gaidys, seseris
+      'as' 'ias' 'is' 'ys'        // vyras, kelias, brolis, gaidys
       'o'    'io'                 // vyro, kelio
       'ui'   'iui'                // vyrui, keliui
       '{ak}' 'i{ak}' '{ik}'       // vyrą, kelią, brolį
@@ -111,21 +111,20 @@ backwardmode (
 
 
       // V linksniuote (declension V)
-      'ies' 'ens' 'enio' 'ers'    // avies, vandens, sesers
-      'eniui' 'eriai' 'eriui'     // vandeniui, seseriai, bleberiui
-      'en{ik}' 'er{ik}'           // vandenį, seserį
-      'imi' 'eniu' 'erimi' 'eria' // avimi, vandeniu, seserimi, seseria
-      'enyje' 'eryje'             // vandenyje, seseryje
-      'ie' 'enie' 'erie'          // avie, vandenie, seserie
+      'ies' 'ens' 'enio'          // avies, vandens, sesers
+      'eniui'                     // vandeniui
+      'en{ik}'                    // vandenį
+      'imi' 'eniu'                // avimi, vandeniu
+      'enyje'                     // vandenyje
+      'ie' 'enie'                 // avie, vandenide
 
-      'enys' 'erys'               // vandenys, seserys
+      'enys'                      // vandenys
       // 'en{uk}' konfliktas su 'žandenų' 'antenų'
-      'er{uk}'                    // seserų
-      'ims' 'enims' 'erims'       // avims, vandemins, seserims
+      'ims' 'enims'               // avims, vandemins
       'enis'                      // vandenis
       'imis'                      // žebenkštimis
       'enimis'                    // vandenimis
-      'yse' 'enyse' 'eryse'       // avyse, vandenyse, seseryse
+      'yse' 'enyse'               // avyse, vandenyse
 
 
       // Būdvardžiai (Adjectives)


### PR DESCRIPTION
The current Lithuanian stemmer implementation causes problems for semi international words and their plural forms such as:

kompiuteris, printeris, lazeris (computer, printer, lazer)

While these aren't fully Lithuanian words they are very commonly used when searching for products in Lithuanian.

To motivate this change further even the current examples in algorithm are also broken for real native Lithuanian words. For example:
sesers, seseris, seseriai produce different stems. (sister in english)

Another example of current stemmer generating different stems:
moteris, moteriai (woman in english)

I have produced a small dataset of examples of word stems before changes:

(Native lithuanian)
seseris -> seser
seseriai -> ses
moteris -> moter
moteriai -> mot
moterimi -> mot
moterų -> mot

(Semi native)
kompiuteris -> kompiuter
kompiuteriai -> kompiut
kompiuteriui -> kompiuter
printeris -> printer
printeriai -> print
printeriui -> printer

And after the fix: 

(Native lithuanian)
seseris -> ses
seseriai -> ses
moteris -> mot
moteriai -> mot
moterimi -> mot
moterų -> mot

(Semi native)
kompiuteris -> kompiut
kompiuteriai -> kompiut
kompiuteriui -> kompiut
printeris -> print
printeriai -> print
printeriui -> print