### PR TITLE
Zig: require 0.16.0 stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
       if: matrix.ZIG
       uses: mlugg/setup-zig@v2
       with:
-        version: master
+        version: 0.16.0
     - name: Install mingw64 packages
       if: matrix.mingw64_packages
       uses: msys2/setup-msys2@v2

--- a/NEWS
+++ b/NEWS
@@ -4,7 +4,7 @@ Snowball 3.0.2 (unreleased)
 Zig
 ---
 
-* Add Zig backend.  Requires Zig 0.16-dev or later.
+* Add Zig backend.  Requires Zig 0.16.0 or later.
 
 Snowball 3.0.1 (2025-05-09)
 ===========================


### PR DESCRIPTION
Zig 0.16.0 was released; pin CI and update the NEWS entry from `0.16-dev` to `0.16.0`.