### PR TITLE
tamil: accusative -னை preserves stem consonant ன்

### DIFF
--- a/algorithms/tamil.sbl
+++ b/algorithms/tamil.sbl
@@ -277,7 +277,13 @@ define remove_vetrumai_urupukal as (
    test (
      [substring] among (
        '{nnna}{vs_ai}'
-         ( delete )
+         // Accusative -னை on a noun stem: strip only the suffix vowel-sign
+         // (vs_ai = ை) and restore the pulli on the consonant ன, so the stem
+         // matches the nominative form (-ன்). Previously this rule deleted
+         // both the vowel-sign and the consonant, producing a truncated stem
+         // that did not collide with the nominative or other case forms
+         // (e.g. கர்ணனை -> கர்ண, while கர்ணன் -> கர்ணன்).
+         ( <- '{nnna}{pulli}' )
        '{vs_o}{tta}{vs_u}'
        '{vs_oo}{tta}{vs_u}'
        '{vs_i}{la}{pulli}'


### PR DESCRIPTION
## Bug

The rule `'{nnna}{vs_ai}' (delete)` at `algorithms/tamil.sbl:279` (inside `remove_vetrumai_urupukal` — "remove case suffixes") deleted both the consonant `ன` (U+0BA9) and the vowel-sign `ை` (U+0BC8) when stripping the Tamil accusative case suffix `-னை`. This left `-ன்`-ending masculine nouns with a truncated stem that did not match their nominative form, breaking inflection-class collapse across the corpus.

| input | upstream | fixed |
|---|---|---|
| `கர்ணன்` (nom) | `கர்ணன்` | `கர்ணன்` |
| `கர்ணனை` (acc) | `கர்ண` ❌ | `கர்ணன்` ✓ |
| `கர்ணனால்` (instr) | `கர்ணன்` | `கர்ணன்` |
| `கர்ணனின்` (gen) | `கர்ணன்` | `கர்ணன்` |
| `பீமனை` (acc) | `பீம` ❌ | `பீமன்` ✓ |
| `ஃபவுண்டேஷனை` (acc) | `ஃபவுண்டேஷ` ❌ | `ஃபவுண்டேஷன்` ✓ |
| `ஹோர்மோனை` (acc) | `ஹோர்மோ` ❌ | `ஹோர்மோன்` ✓ |

`-ர்`-ending masculine nouns are not affected: their accusative is `-ரை` (handled by a different rule that already preserves `-ர்`). Pronouns shorter than 5 characters (`அவன்` / `அவனை`) are not touched because `has_min_length` requires `len > 4`.

## Fix

Change the rule body from `delete` to `<- '{nnna}{pulli}'`: instead of deleting the bigram `னை`, replace it with `ன்` (consonant + pulli), restoring the canonical nominative form. One-line behavioural change.

## Cross-validation against snowball-data

Stemmed the full `snowball-data/tamil/voc.txt` (443,271 words) with both upstream and patched algorithms. Diff:

- **2,785 entries change** (1.25% of the corpus)
- 1,283 gain a final `ன்`/`ண்` consonant that belongs to the noun stem (`-னை` directly stripped — the bug). New stems are longer.
- 1,329 reach a deeper dictionary root because the corrected mid-step now allows downstream rules to fire that previously couldn't (e.g. `அதிகாரத்தினை: அதிகாரத்தி -> அதிகாரம்`, the dictionary form for "authority"). New stems are shorter but more correct.
- 173 end at the same length but a different consonant.

Manual inspection across each bucket: all changes are corrections, none introduce regressions. The companion data PR (snowball-data#fix/tamil-accusative-nai) regenerates `tamil/output.txt` so CI passes against this branch.

## History

This rule has been unchanged since at least the September 2023 optimization pass. The bug is upstream of all consumers (Python `snowballstemmer`, the Go `blevesearch/snowballstem` port, etc.). Tested with snowball master at HEAD before applying the patch.
