### PR TITLE
french: Add “ç” to the list of elision letters

### DIFF
--- a/algorithms/french.sbl
+++ b/algorithms/french.sbl
@@ -40,7 +40,7 @@ define v 'aeiouy{a^}{a`}{e"}{e'}{e^}{e`}{i"}{i^}{o^}{u^}{u`}'
 define oux_ending 'bhjlnp'
 
 // Single character elisions
-define elision_char 'cdjlmnst'
+define elision_char 'c{cc}djlmnst'
 
 define elisions as
 (


### PR DESCRIPTION
“Ç’” is the rare but unambiguous elided form of “ce” or “ça” before hard vowels, as in “ce”/“ça” + “a” → “ç’a”. See snowballstem/snowball-data#38 and snowballstem/snowball-website#50.