### PR TITLE
Add Dockerfile for a reproducible build/test environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:22.04
+
+RUN apt update && apt install -y \
+    build-essential \
+    perl \
+    git \
+    python3 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app

--- a/README.rst
+++ b/README.rst
@@ -84,3 +84,32 @@ like this for the libstemmer build::
     make CC=x86_64-w64-mingw32-gcc EXEEXT=.exe
 
 When going the other way, you'll need to use ``EXEEXT=``.
+
+Test Environment
+-----------------
+A Dockerfile is provided to create a consistent build environment for Snowball.
+This is particularly useful for testing or if you don't want to install the required toolchain on your host system.
+
+Build the Docker image
+From the root of the Snowball repository, run:
+
+```bash
+docker build -t snowball-dev .
+Run the container
+Mount your current directory (the repository) to /app inside the container and start an interactive shell:
+```
+
+```bash
+docker run --rm -it \
+  -v ${PWD}:/app \
+  snowball-dev
+Build Snowball inside the container
+Once inside the container, simply run:
+```
+
+```bash
+make
+```
+The container includes all necessary dependencies (e.g., a C99 compiler, GNU make).
+When you exit the shell, the container is automatically removed (thanks to --rm). Any generated files will remain on your host because the repository is mounted.
+


### PR DESCRIPTION
This PR adds a Dockerfile and updates the README.md with instructions for using it to create a consistent Snowball build environment.

Motivation
Building Snowball requires a C99 compiler and GNU make. While these are standard on many systems, setting up or configuring them can sometimes be a hurdle – especially for new contributors, for testing across different environments, or for users who prefer isolated builds. A Docker container provides:

A reproducible environment independent of the host system.

An easy on-ramp for trying out Snowball without installing dependencies locally.

A consistent test bed for continuous integration or local experimentation.

Changes
Dockerfile

Based on a lightweight Linux distribution (e.g., Alpine or Debian slim).

Installs gcc, make, and any other required build tools.

Sets /app as the working directory.

The container is designed to be used interactively with the repository mounted as a volume.

README.md

Added a new subsection “Test Environment” under the “Building Snowball” section.

Provides step‑by‑step commands to build the Docker image, run the container (mounting the current directory), and execute make inside the container.

Explains the --rm flag and that generated files persist on the host.

Example usage
bash
docker build -t snowball-dev .
docker run --rm -it -v ${PWD}:/app snowball-dev
make
Additional notes
The Dockerfile is intentionally minimal – it includes only the dependencies needed to run make and the Snowball compiler.

No root privileges are required inside the container for normal builds.

This change does not alter any existing build paths or require Docker to use Snowball; it is purely an optional convenience.