### PR TITLE
Avoid a segfault in the analyser

### DIFF
--- a/compiler/analyser.c
+++ b/compiler/analyser.c
@@ -1393,7 +1393,7 @@ static struct node * read_C(struct analyser * a) {
             struct node * n = new_string_command(a, token);
             if (n->name) {
                 n->name->value_used = true;
-            } else if (SIZE(n->literalstring) == 0) {
+            } else if (n->literalstring == NULL || SIZE(n->literalstring) == 0) {
                 switch (token) {
                   case c_insert:
                   case c_attach:


### PR DESCRIPTION
The `errors/string-omitted` test segfaults without this.  From an attempt to build for Fedora Rawhide:
```
$ make check
cd tests && ./compilertest
1..12
ok - errors/ae-errors
ok - errors/bad-dollar
ok - errors/bad-grouping-definition
ok - errors/missing-bra
ok - errors/missing-command
ok - errors/missing-ket-backwardmode
ok - errors/missing-ket
ok - errors/notdefined
./compilertest: line 10:  2066 Segmentation fault         (core dumped) $SNOWBALL -syntax "$t" 2> tmp.stderr > tmp.syntax
ok - errors/string-omitted
ok - errors/undeclared
ok - errors/unexpected-token
ok - errors/wrongdirection
```

This also means that `tests/compilertest` does not consider a segfault to be a test failure, unless it results in a difference in stderr output.  This test doesn't have expected output, so the test is considered to pass in spite of the segfault.