### PR TITLE
Generate valid jsdoc type for `stem`.

### DIFF
--- a/compiler/generator_js.c
+++ b/compiler/generator_js.c
@@ -1172,7 +1172,7 @@ static void generate_define(struct generator * g, struct node * p) {
     if (q->type == t_external) {
         w(g, "~N");
         w(g, "~M/**@return{string}*/~N");
-        writef(g, "~M~W(/**string*/input) {~+~N", p);
+        writef(g, "~M~W(/**@type {string}*/input) {~+~N", p);
         w(g, "~Mthis.setCurrent(input);~N");
         writef(g, "~Mthis.#~W();~N", p);
         w(g, "~Mreturn this.getCurrent();~N");


### PR DESCRIPTION
This is the current `-stemmer.js` output:

```js
    /**@return{string}*/
    stem(/**string*/input) {
        this.setCurrent(input);
        this.#stem();
        return this.getCurrent();
    }
```

which is `(method) default.stem(input: any): string` in TypeScript.

Proposed output:

```js
    /**@return{string}*/
    stem(/**@type {string}*/input) {
        this.setCurrent(input);
        this.#stem();
        return this.getCurrent();
    }
```

which gives `(method) default.stem(input: string): string`.